### PR TITLE
[chore]: npm run lint명령어 max warning 옵션 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
     "test": "jest",
     "preview": "vite preview",
     "gitconfig": "git config --local include.path ./.gitconfig",


### PR DESCRIPTION
### 💁‍♂️ PR 개요

`npm run lint` 명령어에서 ESLint에서 발생시키는 warning을 고려하지 않도록 수정 합니다
- #23 

<br/>

### 📝 변경 사항

```
"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
```
에서 `--max-warnings 0` 를 제거 합니다.

개발을 진행하다가 의도치 않은 사소한 사항들 (ex. 선언 후 사용하지 않는 변수)을 매번 전부 수정하는 것을 강요하는 것 보다
개발 생산성을 위해 이처럼 별 문제 없는 warning사항들은 CI 검사에서 제외를 해도 된다고 생각을 해서 제거했습니다.
그렇지만 , 이후에 warning을 검사해야 하는 상황이 생긴다면 곧바로 수정하겠습니다.

<br/>

### 📷 스크린 샷 (선택)

<br/>

### 🗣 리뷰어한테 할 말 (선택)

혹시라도 문제가 될 것 같은 부분이 생긴다면 바로 말씀 해 주세요!

<br/>

### 🧪 테스트 범위 (선택)

- 테스트 계획
- 테스트 완료 사항
