### PR TITLE
[refactor]: submit/:problemId URL에서도 메뉴바 상태 업데이트 진행

### DIFF
--- a/src/components/layout/CommonLayoutWithMenus.tsx
+++ b/src/components/layout/CommonLayoutWithMenus.tsx
@@ -15,14 +15,14 @@ const CommonLayoutWithMenus = () => {
 
   useEffect(() => {
     const decideProblemId = () => {
-      // 다른 형태의 URL이라면 문제는 선택이 됐고 , 이외의 기능(내 제출 등..)을 사용하는 것이므로
-      // problemId는 로컬스토리지에서 사용
+      // 다른 형태의 URL이라면 문제는 이미 선택이 됐고 , 이외의 기능(내 제출 등..)을 사용하는 것이므로
+      // problemId는 로컬스토리지에 저장된 값을 사용
       if (!checkURL(location.pathname)) {
         const problemIdFromLocalStorage = JSON.parse(localStorage.getItem('problemId')!);
         setCurrentProblemId(problemIdFromLocalStorage);
       }
 
-      // problem/:problemId 형태의 URL이라면 :problemId 사용
+      // problem/:problemId 형태의 URL이라면 :problemId 사용 및 로컬스토리지 저장
       if (checkURL(location.pathname)) {
         localStorage.setItem('problemId', JSON.stringify(problemId));
         setCurrentProblemId(Number(problemId));

--- a/src/util/problem.ts
+++ b/src/util/problem.ts
@@ -1,10 +1,5 @@
 export const checkURL = (pathname: string) => {
-  const regex = /problem/g;
-  const result = pathname.match(regex);
-
-  if (result === null) {
-    return false;
-  }
-
-  return true;
+  const pattern = /^\/(problem|submit)\/\d+/;
+  console.log(pattern.test(pathname));
+  return pattern.test(pathname);
 };

--- a/src/util/problem.ts
+++ b/src/util/problem.ts
@@ -1,5 +1,4 @@
 export const checkURL = (pathname: string) => {
   const pattern = /^\/(problem|submit)\/\d+/;
-  console.log(pattern.test(pathname));
   return pattern.test(pathname);
 };


### PR DESCRIPTION
### 💁‍♂️ PR 개요

문제 페이지에서 사용되는 메뉴 바에는 현재 선택한 문제의 정보를 상태로 가지고 있습니다

- 기존에는 `problem/:problemId` 의 경로로 접근할때만 메뉴 바가 들고 있는 문제 정보의 상태를 업데이트 했지만
- `submit/:problemId` URL에서도 메뉴 바가 들고 있는 문제 정보의 상태를 업데이트 합니다

이렇게 수정한 이유는 다음과 같습니다.

원래는 제출하기 페이지로 접근하는 방식이 아래와 같았습니다
```
문제 선택 -> 문제 정보 제공 페이지 -> (제출하기 버튼 클릭) -> 제출하기 페이지
```
그러므로 문제 정보 제공 페이지인 `problem/:problemId` 경로로 접근할때만 메뉴 바가 들고 있는 문제 정보의 상태를 업데이트를 하고 , 나머지 페이지(제출 페이지 , 정답 보기 등등..)에서는 해당 상태를 그대로 사용합니다

그렇지만, 타입 챌린지 특성상 문제 갯수가 얼마 되지 않고 , 문제ID를 기반으로 문제에 접근하는 유저들도 있습니다.
 **그러므로 가끔씩 ID만 가지고 제출 페이지로 바로 이동하기 위해 URL에다가 `submit/:problemId` 를 입력해서 제출 페이지로 진입하는 경우가 있을 수도 있으므로**
이를 대비하기 위해 해당 URL에도 메뉴바 상태를 업데이트하는 로직을 진행 합니다

- #3 

<br/>

### 📝 변경 사항


```
  <Routes>
        <Route path={PAGE_URL.Main} element={<CommonLayout />}>
          <Route index element={<Switch.MainPage />} />
        </Route>
        <Route path="/*" element={<CommonLayoutWithMenus />}>
          <Route path={`${PAGE_URL.Problem}/:problemId`} element={<Switch.ProblemPage />} />
          <Route path={`${PAGE_URL.Submit}/:problemId`} element={<Switch.Submit />} />
          <Route path={`${PAGE_URL.Status}`} element={<Switch.Status />} />
        </Route>
      </Routes>
```
위의 라우팅 구조에서 
- `${PAGE_URL.Problem}/:problemId` 뿐만 아니라
-  `${PAGE_URL.Submit}/:problemId` 형태의 URL로 접근해도 
`CommonLayoutWithMenus.tsx`에서 상태 업데이트를 하도록 변경합니다
`CommonLayoutWithMenus`에서 상태 업데이트를 해야 할지 판별하는 유틸 함수인 `checkURL` 함수에 `submit`으로 시작하는 URL이 들어와도 `true`를 반환 합니다

<br/>

### 📷 스크린 샷 (선택)


<br/>

### 🗣 리뷰어한테 할 말 (선택)

<br/>

### 🧪 테스트 범위 (선택)

- 테스트 계획
- 테스트 완료 사항
