### PR TITLE
[feat]: 문제 페이지 TS온라인에서 풀이 버튼 추가

### DIFF
--- a/src/components/core/button/ProblemButton.css.ts
+++ b/src/components/core/button/ProblemButton.css.ts
@@ -1,1 +1,10 @@
 import { style } from '@vanilla-extract/css';
+
+export const MenuButton = style({
+  backgroundColor: 'transparent',
+  padding: '0 100px',
+  border: 'none',
+  borderRight: '1px solid black',
+  height: '100%',
+  cursor: 'pointer',
+});

--- a/src/components/core/button/ProblemMenuButtons.tsx
+++ b/src/components/core/button/ProblemMenuButtons.tsx
@@ -1,4 +1,4 @@
-import { MenuButton } from '../../widget/problemmenus/ProblemMenus.css';
+import { MenuButton } from './ProblemButton.css';
 
 interface ProblemMenuButtonsProps {
   text: string;

--- a/src/components/core/button/TsOnlineButton.css.ts
+++ b/src/components/core/button/TsOnlineButton.css.ts
@@ -1,0 +1,11 @@
+import { style } from '@vanilla-extract/css';
+
+export const TsOnlineButtonStyle = style({
+  backgroundColor: '#3178C6',
+  fontSize: '0.9rem',
+  color: 'white',
+  border: 'none',
+  padding: '10px 20px',
+  borderRadius: '5px',
+  cursor: 'pointer',
+});

--- a/src/components/core/button/TsOnlineButton.tsx
+++ b/src/components/core/button/TsOnlineButton.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { TsOnlineButtonStyle } from './TsOnlineButton.css';
+
+interface TsOnlineButtonProps {
+  text: string;
+  _onClick: () => void;
+}
+const TsOnlineButton = ({ text, _onClick }: TsOnlineButtonProps) => {
+  return (
+    <button className={TsOnlineButtonStyle} type="button" onClick={_onClick}>
+      {text}
+    </button>
+  );
+};
+
+export default TsOnlineButton;

--- a/src/components/layout/CommonLayoutWithMenus.css.ts
+++ b/src/components/layout/CommonLayoutWithMenus.css.ts
@@ -4,4 +4,13 @@ export const CommonLayoutStyle = style({
   width: '70%',
   margin: '0 auto',
   minHeight: 'calc(100vh - 61.77px)',
+
+  '@media': {
+    'screen and (min-width: 768px)': {
+      padding: '0 60px',
+    },
+    'screen and (max-width: 767px)': {
+      padding: '0 25px',
+    },
+  },
 });

--- a/src/components/widget/probleminfo/ProblemInfo.tsx
+++ b/src/components/widget/probleminfo/ProblemInfo.tsx
@@ -1,12 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
-import { getProblemList } from '../../../apis/get';
 import { Title } from './title';
 import { Template } from './template';
 import { Example } from './example';
 import { Testcases } from './testcases';
 import { ProblemInfoType } from '@/type/problem';
-import { MenuButton } from '../problemmenus/ProblemMenus.css';
+import TsOnlineButton from '@/components/core/button/TsOnlineButton';
 
 interface ProblemInfoProps {
   problemInfo: ProblemInfoType;
@@ -17,6 +15,11 @@ const ProblemInfo = ({ problemInfo }: ProblemInfoProps) => {
       {problemInfo !== null && (
         <div>
           <Title problemInfo={problemInfo} />
+
+          <TsOnlineButton
+            text="TS 온라인에서 풀이"
+            _onClick={() => (window.location.href = 'https://www.typescriptlang.org/play')}
+          ></TsOnlineButton>
 
           <p>{problemInfo.problemDescription}</p>
 

--- a/src/components/widget/problemmenus/ProblemMenus.css.ts
+++ b/src/components/widget/problemmenus/ProblemMenus.css.ts
@@ -7,11 +7,3 @@ export const ButtonList = style({
   justifyContent: 'flex-start',
   paddingLeft: '0',
 });
-
-export const MenuButton = style({
-  backgroundColor: 'transparent',
-  padding: '0 100px',
-  border: 'none',
-  borderRight: '1px solid black',
-  height: '100%',
-});


### PR DESCRIPTION
### 💁‍♂️ PR 개요

문제 페이지에서 TS 온라인에서 풀이 버튼을 추가 합니다
- #5 

<br/>

### 📝 변경 사항

- `TsOnlineButton.tsx`를 새로 추가하고 이를 `ProblemInfo.tsx`에 추가 합니다

<br/>

### 📷 스크린 샷 (선택)

![image](https://github.com/type-challenges-online-judge/toj-fe/assets/78631876/0516341b-1dd3-4719-874f-e73603cd1ba7)

<br/>

### 🗣 리뷰어한테 할 말 (선택)


<br/>

### 🧪 테스트 범위 (선택)

close #5 