### PR TITLE
Create ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: TOJ CI
+
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥저장소의 코드 가져오기
+        uses: actions/checkout@v3
+
+      - name: 🏷노드 버전 설정
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.17.1
+
+      - name: 💽노드 패키지 캐싱
+        uses: actions/cache@v3
+        id: npm-cache
+        with:
+          path: ./node_modules
+          key: ${{ github.event.repository.name }}-node-${{ hashFiles('**/package-lock.json') }}
+
+      - name: 📦패키지 설치 (캐시되지 않았을 경우)
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - run: npm run lint --if-present
+      - run: npm run test --if-present
+      - run: npm run build --if-present


### PR DESCRIPTION
### 💁‍♂️ PR 개요

- 새로운 `ci.yml` 를 도입합니다

<br/>

### 📝 변경 사항

-  `ci.yml`  추가
    - node_modules 폴더를 캐싱하지 않고, 홈 디렉터리의 .npm 폴더를 잘못 캐싱하고 있던 문제를 수정
    
     - 테스트가 일어나는 환경의 노드 버전을 사전에 이야기 한 18.17.1 버전으로 고정하는 스크립트를 추가

<br/>

### 📷 스크린 샷 (선택)

![image](https://github.com/type-challenges-online-judge/toj-fe/assets/78631876/49020450-2f8a-4b31-9737-89df1b7bc988)

<br/>

### 🗣 리뷰어한테 할 말 (선택)

<br/>

### 🧪 테스트 범위 (선택)
