### PR TITLE
♻️ [refactor]: queryFn 공통로직 분리, 전역 useQuery 적용

### DIFF
--- a/src/components/layout/CommonLayoutWithMenus.tsx
+++ b/src/components/layout/CommonLayoutWithMenus.tsx
@@ -13,7 +13,7 @@ import { getProblems } from '@/apis/get';
 import { MainProblem } from '@/type/problem';
 
 // util
-import { checkURL, getProblemDataById } from '@/util/problem';
+import { checkURL, fetchProblemDataById, getProblemDataById } from '@/util/problem';
 
 const CommonLayoutWithMenus = () => {
   const { problemId } = useParams();
@@ -26,7 +26,7 @@ const CommonLayoutWithMenus = () => {
       // 다른 형태의 URL이라면 문제는 이미 선택이 됐고 , 이외의 기능(내 제출 등..)을 사용하는 것이므로
       // problemId는 로컬스토리지에 저장된 값을 사용
       if (!checkURL(location.pathname)) {
-        const problemIdFromLocalStorage = JSON.parse(localStorage.getItem('problemId')!);
+        const problemIdFromLocalStorage = Number(JSON.parse(localStorage.getItem('problemId')!));
         setCurrentProblemId(problemIdFromLocalStorage);
       }
 
@@ -39,13 +39,11 @@ const CommonLayoutWithMenus = () => {
     decideProblemId();
   }, [location.pathname, problemId]);
 
-  const { data } = useQuery({
-    queryKey: ['problemInfo', { problemId: Number(currentProblemId) }],
-    queryFn: async () => {
-      const res: MainProblem = await getProblems();
+  console.log(problemId);
 
-      return getProblemDataById(res, Number(problemId));
-    },
+  const { data } = useQuery({
+    queryKey: ['problemInfo', { problemId: currentProblemId }],
+    queryFn: async () => await fetchProblemDataById(currentProblemId!),
     staleTime: Infinity,
     enabled: currentProblemId !== null,
   });

--- a/src/components/layout/CommonLayoutWithMenus.tsx
+++ b/src/components/layout/CommonLayoutWithMenus.tsx
@@ -6,14 +6,8 @@ import { CommonLayoutStyle } from './CommonLayoutWithMenus.css';
 // components
 import { ProblemMenus } from '@/components/widget';
 
-// api
-import { getProblems } from '@/apis/get';
-
-// types
-import { MainProblem } from '@/type/problem';
-
 // util
-import { checkURL, fetchProblemDataById, getProblemDataById } from '@/util/problem';
+import { checkURL, fetchProblemDataById } from '@/util/problem';
 
 const CommonLayoutWithMenus = () => {
   const { problemId } = useParams();
@@ -23,14 +17,11 @@ const CommonLayoutWithMenus = () => {
 
   useEffect(() => {
     const decideProblemId = () => {
-      // 다른 형태의 URL이라면 문제는 이미 선택이 됐고 , 이외의 기능(내 제출 등..)을 사용하는 것이므로
-      // problemId는 로컬스토리지에 저장된 값을 사용
       if (!checkURL(location.pathname)) {
         const problemIdFromLocalStorage = Number(JSON.parse(localStorage.getItem('problemId')!));
         setCurrentProblemId(problemIdFromLocalStorage);
       }
 
-      // problem/:problemId 형태의 URL이라면 :problemId 사용 및 로컬스토리지 저장
       if (checkURL(location.pathname)) {
         localStorage.setItem('problemId', JSON.stringify(problemId));
         setCurrentProblemId(Number(problemId));
@@ -38,8 +29,6 @@ const CommonLayoutWithMenus = () => {
     };
     decideProblemId();
   }, [location.pathname, problemId]);
-
-  console.log(problemId);
 
   const { data } = useQuery({
     queryKey: ['problemInfo', { problemId: currentProblemId }],

--- a/src/components/widget/probleminfo/ProblemInfo.tsx
+++ b/src/components/widget/probleminfo/ProblemInfo.tsx
@@ -8,30 +8,36 @@ import { Testcases } from './testcases';
 import { TsOnlineButton } from '@/components/core';
 
 // types
-import { ProblemInfoType } from '@/type/problem';
+import { fetchProblemDataById } from '@/util/problem';
+import { useQuery } from '@tanstack/react-query';
 
-interface ProblemInfoProps {
-  problemInfo: { problemDiff: string; problemInfo: ProblemInfoType };
-}
-const ProblemInfo = ({ problemInfo }: ProblemInfoProps) => {
+const ProblemInfo = () => {
+  const problemId: number = Number(JSON.parse(localStorage.getItem('problemId')!));
+  // 캐싱 데이터 사용 (없을 경우 queryFn 적용)
+  const { data } = useQuery({
+    queryKey: ['problemInfo', { problemId: Number(problemId) }],
+    queryFn: async () => await fetchProblemDataById(Number(problemId)),
+    staleTime: Infinity,
+  });
+
   return (
     <>
-      {problemInfo !== null && (
+      {data !== undefined && (
         <div>
-          <Title problemInfo={problemInfo} />
+          <Title problemInfo={data} />
 
           <TsOnlineButton
             text="TS 온라인에서 풀이"
             _onClick={() => (window.location.href = 'https://www.typescriptlang.org/play')}
           ></TsOnlineButton>
 
-          <p>{problemInfo.problemInfo.problemDescription}</p>
+          <p>{data?.problemInfo.problemDescription}</p>
 
-          <Example problemInfo={problemInfo} />
+          <Example problemInfo={data} />
 
-          <Template problemInfo={problemInfo} />
+          <Template problemInfo={data} />
 
-          <Testcases problemInfo={problemInfo} />
+          <Testcases problemInfo={data} />
         </div>
       )}
     </>

--- a/src/components/widget/probleminfo/example/Example.tsx
+++ b/src/components/widget/probleminfo/example/Example.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { ProblemCategoryStyle, ProblemCodeBlockStyle, ProblemCodeStyle } from '../ProblemInfo.css';
 
 // types
-import { ProblemInfoType } from '@/type/problem';
+import { Level, ProblemInfoType } from '@/type/problem';
 
 interface ExampleProps {
-  problemInfo: { problemDiff: string; problemInfo: ProblemInfoType };
+  problemInfo: { problemDiff: Level; problemInfo: ProblemInfoType };
 }
 
 const Example = ({ problemInfo }: ExampleProps) => {
@@ -14,7 +14,7 @@ const Example = ({ problemInfo }: ExampleProps) => {
       <p className={ProblemCategoryStyle}>예시</p>
       <pre className={ProblemCodeBlockStyle}>
         <code className={ProblemCodeStyle}>
-          {problemInfo.problemInfo.example.map((line) => `${line}\n\n`)}
+          {problemInfo?.problemInfo.example.map((line) => `${line}\n\n`)}
         </code>
       </pre>
     </div>

--- a/src/components/widget/probleminfo/template/Template.tsx
+++ b/src/components/widget/probleminfo/template/Template.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { ProblemCategoryStyle, ProblemCodeBlockStyle, ProblemCodeStyle } from '../ProblemInfo.css';
 
 // types
-import { ProblemInfoType } from '@/type/problem';
+import { Level, ProblemInfoType } from '@/type/problem';
 
 interface TemplateProps {
-  problemInfo: { problemDiff: string; problemInfo: ProblemInfoType };
+  problemInfo: { problemDiff: Level; problemInfo: ProblemInfoType };
 }
 const Template = ({ problemInfo }: TemplateProps) => {
   return (
@@ -14,7 +14,7 @@ const Template = ({ problemInfo }: TemplateProps) => {
 
       <pre className={ProblemCodeBlockStyle}>
         <code className={ProblemCodeStyle}>
-          {problemInfo.problemInfo.template.map((line) => `${line}\n\n`)}
+          {problemInfo?.problemInfo.template.map((line) => `${line}\n\n`)}
         </code>
       </pre>
     </div>

--- a/src/components/widget/probleminfo/testcases/Testcases.tsx
+++ b/src/components/widget/probleminfo/testcases/Testcases.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { ProblemCategoryStyle, ProblemCodeBlockStyle, ProblemCodeStyle } from '../ProblemInfo.css';
 
 // types
-import { ProblemInfoType } from '@/type/problem';
+import { Level, ProblemInfoType } from '@/type/problem';
 
 interface TestcasesProps {
-  problemInfo: { problemDiff: string; problemInfo: ProblemInfoType };
+  problemInfo: { problemDiff: Level; problemInfo: ProblemInfoType };
 }
 
 const Testcases = ({ problemInfo }: TestcasesProps) => {
@@ -14,7 +14,7 @@ const Testcases = ({ problemInfo }: TestcasesProps) => {
       <p className={ProblemCategoryStyle}>테스트 케이스</p>
       <pre className={ProblemCodeBlockStyle}>
         <code className={ProblemCodeStyle}>
-          {problemInfo.problemInfo.testCases.map((line) => `${line}\n\n`)}
+          {problemInfo?.problemInfo.testCases.map((line) => `${line}\n\n`)}
         </code>
       </pre>
     </div>

--- a/src/components/widget/probleminfo/title/Title.tsx
+++ b/src/components/widget/probleminfo/title/Title.tsx
@@ -5,7 +5,7 @@ import { ProblemDiffStyle, ProblemTitleStyle } from '../ProblemInfo.css';
 import { Level, ProblemInfoType } from '@/type/problem';
 
 interface TitleProps {
-  problemInfo: { problemDiff: string; problemInfo: ProblemInfoType };
+  problemInfo: { problemDiff: Level; problemInfo: ProblemInfoType };
 }
 
 const Title = ({ problemInfo }: TitleProps) => {
@@ -13,8 +13,8 @@ const Title = ({ problemInfo }: TitleProps) => {
     <div>
       <p className={ProblemTitleStyle}>
         {problemInfo.problemInfo.problemTitle}
-        <span className={ProblemDiffStyle[problemInfo.problemDiff as Level]}>
-          {problemInfo.problemDiff}
+        <span className={ProblemDiffStyle[problemInfo?.problemDiff]}>
+          {problemInfo?.problemDiff}
         </span>
       </p>
     </div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,13 @@ import { worker } from './mocks/worker';
 if (process.env.NODE_ENV === 'development') {
   worker.start();
 }
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>

--- a/src/pages/problem/ProblemPage.tsx
+++ b/src/pages/problem/ProblemPage.tsx
@@ -13,7 +13,7 @@ import { getProblems } from '@/apis/get';
 import { MainProblem } from '@/type/problem';
 
 // util
-import { getProblemDataById } from '@/util/problem';
+import { fetchProblemDataById, getProblemDataById } from '@/util/problem';
 
 const ProblemPage = () => {
   const { problemId } = useParams();
@@ -21,10 +21,7 @@ const ProblemPage = () => {
   // 캐싱 데이터 사용 (없을 경우 queryFn 적용)
   const { data } = useQuery({
     queryKey: ['problemInfo', { problemId: Number(problemId) }],
-    queryFn: async () => {
-      const res: MainProblem = await getProblems();
-      return getProblemDataById(res, Number(problemId));
-    },
+    queryFn: async () => await fetchProblemDataById(Number(problemId)),
     staleTime: Infinity,
   });
 

--- a/src/pages/problem/ProblemPage.tsx
+++ b/src/pages/problem/ProblemPage.tsx
@@ -1,37 +1,13 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
 import { ProblemPageStyle } from './ProblemPage.css';
-import { useQuery } from '@tanstack/react-query';
 
 // components
 import { ProblemInfo } from '@/components/widget';
 
-// api
-import { getProblems } from '@/apis/get';
-
-// types
-import { MainProblem } from '@/type/problem';
-
-// util
-import { fetchProblemDataById, getProblemDataById } from '@/util/problem';
-
 const ProblemPage = () => {
-  const { problemId } = useParams();
-
-  // 캐싱 데이터 사용 (없을 경우 queryFn 적용)
-  const { data } = useQuery({
-    queryKey: ['problemInfo', { problemId: Number(problemId) }],
-    queryFn: async () => await fetchProblemDataById(Number(problemId)),
-    staleTime: Infinity,
-  });
-
   return (
     <div className={ProblemPageStyle}>
-      {data !== undefined && (
-        <>
-          <ProblemInfo problemInfo={data} />
-        </>
-      )}
+      <ProblemInfo />
     </div>
   );
 };

--- a/src/pages/submit/Submit.tsx
+++ b/src/pages/submit/Submit.tsx
@@ -7,14 +7,8 @@ import 'ace-builds/src-noconflict/theme-tomorrow';
 
 import { CodeInput, CodeInputWrapper } from './Submit.css';
 
-// types
-import { MainProblem } from '@/type/problem';
-
-// api
-import { getProblems } from '@/apis/get';
-
 // util
-import { fetchProblemDataById, getProblemDataById } from '@/util/problem';
+import { fetchProblemDataById } from '@/util/problem';
 
 const Submit = () => {
   const [code, setCode] = useState<string>('');

--- a/src/pages/submit/Submit.tsx
+++ b/src/pages/submit/Submit.tsx
@@ -14,7 +14,7 @@ import { MainProblem } from '@/type/problem';
 import { getProblems } from '@/apis/get';
 
 // util
-import { getProblemDataById } from '@/util/problem';
+import { fetchProblemDataById, getProblemDataById } from '@/util/problem';
 
 const Submit = () => {
   const [code, setCode] = useState<string>('');
@@ -23,11 +23,7 @@ const Submit = () => {
 
   const { data } = useQuery({
     queryKey: ['problemInfo', { problemId: Number(problemId) }],
-    queryFn: async () => {
-      const res: MainProblem = await getProblems();
-      return getProblemDataById(res, Number(problemId));
-    },
-
+    queryFn: async () => await fetchProblemDataById(Number(problemId)),
     staleTime: Infinity,
   });
 

--- a/src/util/problem.ts
+++ b/src/util/problem.ts
@@ -1,6 +1,7 @@
 import { getProblems } from '@/apis/get';
 import { Level, MainProblem } from '@/type/problem';
 
+// "problem/", "submit/"" URL 판별
 export const checkURL = (pathname: string) => {
   const pattern = /^\/(problem|submit)\/\d+/;
   return pattern.test(pathname);
@@ -15,7 +16,6 @@ export const getProblemDataById = (data: MainProblem, targetId: number) => {
 };
 
 export const fetchProblemDataById = async (problemId: number) => {
-  console.log(problemId);
   const res: MainProblem = await getProblems();
   return getProblemDataById(res, problemId);
 };

--- a/src/util/problem.ts
+++ b/src/util/problem.ts
@@ -1,3 +1,4 @@
+import { getProblems } from '@/apis/get';
 import { Level, MainProblem } from '@/type/problem';
 
 export const checkURL = (pathname: string) => {
@@ -11,4 +12,10 @@ export const getProblemDataById = (data: MainProblem, targetId: number) => {
     const filterResult = data[key].filter((i) => i.problemId === targetId);
     if (filterResult.length !== 0) return { problemDiff: key, problemInfo: filterResult[0] };
   }
+};
+
+export const fetchProblemDataById = async (problemId: number) => {
+  console.log(problemId);
+  const res: MainProblem = await getProblems();
+  return getProblemDataById(res, problemId);
 };


### PR DESCRIPTION
### 💁‍♂️ PR 개요

- 기존에 사용하던 useQuery의 queryFn의 공통 로직을 함수 단위로 분리 합니다
- [이전 PR](https://github.com/type-challenges-online-judge/toj-fe/pull/38) 에 작성했던 문제
  > 문제 선택 후 진입하는 ProblemPage.tsx 에서 API를 호출하고 난 데이터를 props로 넘겨주는데 이 깊이가 조금 깊습니다.
`ProblemPage.tsx → ProblemInfo.tsx → Title.tsx ,Example.tsx ,Template.tsx ,Testcases.tsx `
그래서 이걸 개선해야 하는데
간단히 context로 처리할지, 아니면 Zustand로 처리할지 고민을 해봐야 할 것 같습니다

   이 부분을 굳이 context를 이용하거나 Zustand 상태 관리를 이용하는 것 보다, 계속해서 리액트 쿼리로 서버의 상태를
   캐싱 데이터로 가지고 있다가 다른 컴포넌트에서 즉시 호출해서 사용할 수 있도록 하는 것이 더 효율적이라는 생각이 들어서
   useQuery로 사용했습니다

<br/>

### 📝 변경 사항

- 공통된 queryFn를 util 폴더로 분리
- useQuery를 `ProblemInfo.tsx`에서 호출 후  `Title.tsx ,Example.tsx ,Template.tsx ,Testcases.tsx`  로 전달

<br/>

### 📷 스크린 샷 (선택)

<br/>

### 🗣 리뷰어한테 할 말 (선택)

<br/>

### 🧪 테스트 범위 (선택)
