### PR TITLE
♻️ [refactor]: 문제 제출 페이지 변경된 API 로직으로 수정

### DIFF
--- a/src/apis/get.ts
+++ b/src/apis/get.ts
@@ -3,5 +3,6 @@ import axios from 'axios';
 
 export const getProblemDetail = async <T extends ProblemDetailType>(id: number) => {
   const res = await axios.get<T>(`/api/problem/detail/${id}`);
+  console.log(res.data);
   return res.data;
 };

--- a/src/apis/get.ts
+++ b/src/apis/get.ts
@@ -1,8 +1,7 @@
-import { MainProblem, ProblemDetailType } from '@/type/problem';
+import { ProblemDetailType } from '@/type/problem';
 import axios from 'axios';
 
 export const getProblemDetail = async <T extends ProblemDetailType>(id: number) => {
   const res = await axios.get<T>(`/api/problem/detail/${id}`);
-  console.log(res.data);
   return res.data;
 };

--- a/src/apis/get.ts
+++ b/src/apis/get.ts
@@ -1,7 +1,7 @@
-import { MainProblem } from '@/type/problem';
+import { MainProblem, ProblemDetailType } from '@/type/problem';
 import axios from 'axios';
 
-export const getProblems = async <T extends MainProblem>() => {
-  const res = await axios.get<T>('/problems');
+export const getProblemDetail = async <T extends ProblemDetailType>(id: number) => {
+  const res = await axios.get<T>(`/api/problem/detail/${id}`);
   return res.data;
 };

--- a/src/components/layout/CommonLayoutWithMenus.tsx
+++ b/src/components/layout/CommonLayoutWithMenus.tsx
@@ -7,7 +7,9 @@ import { CommonLayoutStyle } from './CommonLayoutWithMenus.css';
 import { ProblemMenus } from '@/components/widget';
 
 // util
-import { checkURL, fetchProblemDataById } from '@/util/problem';
+import { checkURL } from '@/util/problem';
+import { getProblemDetail } from '@/apis/get';
+import { ProblemDetailType } from '@/type/problem';
 
 const CommonLayoutWithMenus = () => {
   const { problemId } = useParams();
@@ -32,14 +34,17 @@ const CommonLayoutWithMenus = () => {
 
   const { data } = useQuery({
     queryKey: ['problemInfo', { problemId: currentProblemId }],
-    queryFn: async () => await fetchProblemDataById(currentProblemId!),
+    queryFn: async () => {
+      const res = await getProblemDetail<ProblemDetailType>(Number(currentProblemId));
+      return res.data;
+    },
     staleTime: Infinity,
     enabled: currentProblemId !== null,
   });
 
   return (
     <div className={CommonLayoutStyle}>
-      {data !== undefined && <ProblemMenus problemInfo={data} />}
+      {data !== undefined && <ProblemMenus problemDetail={data} />}
       <Outlet />
     </div>
   );

--- a/src/components/widget/main/MainProblems.tsx
+++ b/src/components/widget/main/MainProblems.tsx
@@ -10,24 +10,24 @@ import {
 import { LevelLabel, MainProblemButton } from '@/components';
 import { MainLevel, MainProblem, ProblemInfoType } from '@/type/problem';
 import { MAIN_LEVELS } from '@/data/Problems';
-import { getProblems } from '@/apis/get';
+// import { getProblems } from '@/apis/get';
 
 const MainProblems = () => {
   const navigate = useNavigate();
 
   const [problemData, setProblemData] = useState<MainProblem | null>(null);
 
-  useEffect(() => {
-    const getProblemData = async () => {
-      try {
-        const res = await getProblems<MainProblem>();
-        setProblemData(res);
-      } catch (e) {
-        console.error(e);
-      }
-    };
-    getProblemData();
-  }, []);
+  // useEffect(() => {
+  //   const getProblemData = async () => {
+  //     try {
+  //       const res = await getProblems<MainProblem>();
+  //       setProblemData(res);
+  //     } catch (e) {
+  //       console.error(e);
+  //     }
+  //   };
+  //   getProblemData();
+  // }, []);
 
   return (
     <div className={MainProblemsWrapperStyle}>

--- a/src/components/widget/main/MainProblems.tsx
+++ b/src/components/widget/main/MainProblems.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import {
   MainLevelsWrapperStyle,
@@ -7,15 +7,15 @@ import {
   MainProblemsWrapperStyle,
 } from './MainProblems.css';
 
-import { LevelLabel, MainProblemButton } from '@/components';
-import { MainLevel, MainProblem, ProblemInfoType } from '@/type/problem';
-import { MAIN_LEVELS } from '@/data/Problems';
-// import { getProblems } from '@/apis/get';
+// import { LevelLabel, MainProblemButton } from '@/components';
+// import { MainLevel, MainProblem } from '@/type/problem';
+// import { MAIN_LEVELS } from '@/data/Problems';
 
+// 기존 API로직 때문에 에러가 발생하게 되므로 민지님이 추후 수정해 주세요
 const MainProblems = () => {
   const navigate = useNavigate();
 
-  const [problemData, setProblemData] = useState<MainProblem | null>(null);
+  // const [problemData, setProblemData] = useState<MainProblem | null>(null);
 
   // useEffect(() => {
   //   const getProblemData = async () => {
@@ -31,7 +31,7 @@ const MainProblems = () => {
 
   return (
     <div className={MainProblemsWrapperStyle}>
-      {MAIN_LEVELS.map((levelLabel: MainLevel, index: number) => {
+      {/* {MAIN_LEVELS.map((levelLabel: MainLevel, index: number) => {
         return (
           <div key={index} className={MainLevelsWrapperStyle}>
             <LevelLabel level={levelLabel.level} count={levelLabel.count} />
@@ -56,7 +56,7 @@ const MainProblems = () => {
             )}
           </div>
         );
-      })}
+      })} */}
     </div>
   );
 };

--- a/src/components/widget/probleminfo/ProblemInfo.tsx
+++ b/src/components/widget/probleminfo/ProblemInfo.tsx
@@ -6,9 +6,11 @@ import { TsOnlineButton } from '@/components/core';
 import { ProblemDetails } from './problemdetails';
 
 // types
-import { fetchProblemDataById } from '@/util/problem';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
+import { getProblemDetail } from '@/apis/get';
+import { ProblemDetailType } from '@/type/problem';
+import { extractDescription } from '@/util/problem';
 
 const ProblemInfo = () => {
   const { problemId } = useParams();
@@ -16,7 +18,10 @@ const ProblemInfo = () => {
   // 캐싱 데이터 사용 (없을 경우 queryFn 적용)
   const { data } = useQuery({
     queryKey: ['problemInfo', { problemId: Number(problemId) }],
-    queryFn: async () => await fetchProblemDataById(Number(problemId)),
+    queryFn: async () => {
+      const res = await getProblemDetail<ProblemDetailType>(Number(problemId));
+      return res.data;
+    },
     staleTime: Infinity,
   });
 
@@ -24,20 +29,20 @@ const ProblemInfo = () => {
     <>
       {data !== undefined && (
         <div>
-          <Title problemInfo={data} />
+          <Title problemDetail={data} />
 
           <TsOnlineButton
             text="TS 온라인에서 풀이"
             _onClick={() => (window.location.href = 'https://www.typescriptlang.org/play')}
           ></TsOnlineButton>
 
-          <p>{data.problemInfo.problemDescription}</p>
+          <p>{extractDescription(data.description)}</p>
 
-          <ProblemDetails text="예시" codeArr={data.problemInfo.example} />
+          <ProblemDetails text="예시" codeBlock={data.description} />
 
-          <ProblemDetails text="제출 템플릿" codeArr={data.problemInfo.template} />
+          <ProblemDetails text="제출 템플릿" codeBlock={data.template} />
 
-          <ProblemDetails text="테스트케이스" codeArr={data.problemInfo.testCases} />
+          <ProblemDetails text="테스트 케이스" codeBlock={data.testCase} />
         </div>
       )}
     </>

--- a/src/components/widget/probleminfo/problemdetails/ProblemDetails.tsx
+++ b/src/components/widget/probleminfo/problemdetails/ProblemDetails.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { ProblemCategoryStyle, ProblemCodeBlockStyle, ProblemCodeStyle } from '../ProblemInfo.css';
 
 // types
-import { ProblemDetailType, ProblemInfoType } from '@/type/problem';
+import { ProblemDetailType } from '@/type/problem';
 import { extractExample, extractTestCases } from '@/util/problem';
 
 interface codeArrProps {

--- a/src/components/widget/probleminfo/problemdetails/ProblemDetails.tsx
+++ b/src/components/widget/probleminfo/problemdetails/ProblemDetails.tsx
@@ -4,20 +4,38 @@ import React from 'react';
 import { ProblemCategoryStyle, ProblemCodeBlockStyle, ProblemCodeStyle } from '../ProblemInfo.css';
 
 // types
-import { ProblemInfoType } from '@/type/problem';
+import { ProblemDetailType, ProblemInfoType } from '@/type/problem';
+import { extractExample, extractTestCases } from '@/util/problem';
 
 interface codeArrProps {
   text: string;
-  codeArr: ProblemInfoType['example'] | ProblemInfoType['template'] | ProblemInfoType['testCases'];
+  codeBlock:
+    | ProblemDetailType['data']['description']
+    | ProblemDetailType['data']['template']
+    | ProblemDetailType['data']['testCase'];
 }
 
-const ProblemDetails = ({ text, codeArr }: codeArrProps) => {
+const ProblemDetails = ({ text, codeBlock }: codeArrProps) => {
+  const renderBasedOnType = (text: codeArrProps['text'], codeBlock: codeArrProps['codeBlock']) => {
+    if (text === '예시') {
+      return <code className={ProblemCodeStyle}>{extractExample(codeBlock as string)}</code>;
+    }
+    if (text === '제출 템플릿') {
+      return <code className={ProblemCodeStyle}>{codeBlock as string}</code>;
+    }
+    if (text === '테스트 케이스') {
+      return (
+        <code className={ProblemCodeStyle}>
+          {extractTestCases(codeBlock as ProblemDetailType['data']['testCase'])}
+        </code>
+      );
+    }
+  };
+
   return (
     <div>
       <p className={ProblemCategoryStyle}>{text}</p>
-      <pre className={ProblemCodeBlockStyle}>
-        <code className={ProblemCodeStyle}>{codeArr.map((line) => `${line}\n\n`)}</code>
-      </pre>
+      <pre className={ProblemCodeBlockStyle}>{renderBasedOnType(text, codeBlock)}</pre>
     </div>
   );
 };

--- a/src/components/widget/probleminfo/title/Title.tsx
+++ b/src/components/widget/probleminfo/title/Title.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ProblemDiffStyle, ProblemTitleStyle } from '../ProblemInfo.css';
 
 // types
-import { Level, ProblemDetailType, ProblemInfoType } from '@/type/problem';
+import { ProblemDetailType } from '@/type/problem';
 
 interface TitleProps {
   problemDetail: ProblemDetailType['data'];

--- a/src/components/widget/probleminfo/title/Title.tsx
+++ b/src/components/widget/probleminfo/title/Title.tsx
@@ -2,20 +2,18 @@ import React from 'react';
 import { ProblemDiffStyle, ProblemTitleStyle } from '../ProblemInfo.css';
 
 // types
-import { Level, ProblemInfoType } from '@/type/problem';
+import { Level, ProblemDetailType, ProblemInfoType } from '@/type/problem';
 
 interface TitleProps {
-  problemInfo: { problemDiff: Level; problemInfo: ProblemInfoType };
+  problemDetail: ProblemDetailType['data'];
 }
 
-const Title = ({ problemInfo }: TitleProps) => {
+const Title = ({ problemDetail }: TitleProps) => {
   return (
     <div>
       <p className={ProblemTitleStyle}>
-        {problemInfo.problemInfo.problemTitle}
-        <span className={ProblemDiffStyle[problemInfo?.problemDiff]}>
-          {problemInfo?.problemDiff}
-        </span>
+        {problemDetail.title}
+        <span className={ProblemDiffStyle[problemDetail.level]}>{problemDetail.level}</span>
       </p>
     </div>
   );

--- a/src/components/widget/problemmenus/ProblemMenus.tsx
+++ b/src/components/widget/problemmenus/ProblemMenus.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { ProblemMenuButtons } from '@/components/core';
 
 // types
-import { Level, ProblemDetailType, ProblemInfoType } from '@/type/problem';
+import { ProblemDetailType } from '@/type/problem';
 
 // style
 import { SingleButton, ButtonList } from './ProblemMenus.css';

--- a/src/components/widget/problemmenus/ProblemMenus.tsx
+++ b/src/components/widget/problemmenus/ProblemMenus.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { ProblemMenuButtons } from '@/components/core';
 
 // types
-import { Level, ProblemInfoType } from '@/type/problem';
+import { Level, ProblemDetailType, ProblemInfoType } from '@/type/problem';
 
 // style
 import { SingleButton, ButtonList } from './ProblemMenus.css';
@@ -14,10 +14,10 @@ import { SingleButton, ButtonList } from './ProblemMenus.css';
 import { PAGE_URL } from '@/config/path';
 
 interface ProblemMenusProps {
-  problemInfo: { problemDiff: Level; problemInfo: ProblemInfoType };
+  problemDetail: ProblemDetailType['data'];
 }
 
-const ProblemMenus = ({ problemInfo }: ProblemMenusProps) => {
+const ProblemMenus = ({ problemDetail }: ProblemMenusProps) => {
   const navigate = useNavigate();
 
   // 내 제출
@@ -32,11 +32,11 @@ const ProblemMenus = ({ problemInfo }: ProblemMenusProps) => {
       <ul className={ButtonList}>
         <li className={`${SingleButton} isFirst`}>
           <ProblemMenuButtons
-            problemDiff={problemInfo.problemDiff}
-            problemId={problemInfo.problemInfo.problemId}
-            text={problemInfo.problemInfo.problemTitle}
+            problemDiff={problemDetail.level}
+            problemId={problemDetail.id}
+            text={problemDetail.title}
             _onClick={() => {
-              navigate(`/${PAGE_URL.Problem}/${problemInfo.problemInfo.problemId}`);
+              navigate(`/${PAGE_URL.Problem}/${problemDetail.id}`);
             }}
           />
         </li>
@@ -45,7 +45,7 @@ const ProblemMenus = ({ problemInfo }: ProblemMenusProps) => {
           <ProblemMenuButtons
             text="제출하기"
             _onClick={() => {
-              navigate(`/${PAGE_URL.Submit}/${problemInfo.problemInfo.problemId}`);
+              navigate(`/${PAGE_URL.Submit}/${problemDetail.id}`);
             }}
           />
         </li>
@@ -54,7 +54,7 @@ const ProblemMenus = ({ problemInfo }: ProblemMenusProps) => {
             text="답안 보기"
             _onClick={() => {
               navigate(
-                `/${PAGE_URL.Status}?result_id=1&problem_id=${problemInfo.problemInfo.problemId}&user_id=minh0518&mine=false`,
+                `/${PAGE_URL.Status}?result_id=1&problem_id=${problemDetail.id}&user_id=minh0518&mine=false`,
               );
             }}
           />
@@ -64,7 +64,7 @@ const ProblemMenus = ({ problemInfo }: ProblemMenusProps) => {
             text="내 제출"
             _onClick={() => {
               navigate(
-                `/${PAGE_URL.Status}?result_id=-1&problem_id=${problemInfo.problemInfo.problemId}&user_id=minh0518&mine=true`,
+                `/${PAGE_URL.Status}?result_id=-1&problem_id=${problemDetail.id}&user_id=minh0518&mine=true`,
               );
             }}
           />

--- a/src/data/Problems.ts
+++ b/src/data/Problems.ts
@@ -1,5 +1,5 @@
 // import { MainLevel, MainProblems } from '@/type/problem';
-import { MainLevel } from '@/type/problem';
+// import { MainLevel } from '@/type/problem';
 
 // export const MAIN_LEVEL_PROBLEMS: MainProblems = {
 //   'warm-up': [
@@ -160,25 +160,25 @@ import { MainLevel } from '@/type/problem';
 // };
 
 // main
-export const MAIN_LEVELS: MainLevel[] = [
-  {
-    level: 'warm-up',
-    count: 1,
-  },
-  {
-    level: 'easy',
-    count: 13,
-  },
-  {
-    level: 'medium',
-    count: 93,
-  },
-  {
-    level: 'hard',
-    count: 46,
-  },
-  {
-    level: 'extreme',
-    count: 14,
-  },
-];
+// export const MAIN_LEVELS: MainLevel[] = [
+//   {
+//     level: 'warm-up',
+//     count: 1,
+//   },
+//   {
+//     level: 'easy',
+//     count: 13,
+//   },
+//   {
+//     level: 'medium',
+//     count: 93,
+//   },
+//   {
+//     level: 'hard',
+//     count: 46,
+//   },
+//   {
+//     level: 'extreme',
+//     count: 14,
+//   },
+// ];

--- a/src/pages/submit/Submit.css.ts
+++ b/src/pages/submit/Submit.css.ts
@@ -6,6 +6,5 @@ export const CodeInputWrapper = style({
 });
 
 export const CodeInput = style({
-  marginTop: '150px',
-  border: '1px solid black',
+  marginTop: '100px',
 });

--- a/src/pages/submit/Submit.tsx
+++ b/src/pages/submit/Submit.tsx
@@ -1,14 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
-import AceEditor from 'react-ace';
-import 'ace-builds/src-noconflict/mode-typescript';
-import 'ace-builds/src-noconflict/theme-tomorrow';
+// import AceEditor from 'react-ace';
+// import 'ace-builds/src-noconflict/mode-typescript';
+// import 'ace-builds/src-noconflict/theme-tomorrow';
 
 import { CodeInput, CodeInputWrapper } from './Submit.css';
+import { ProblemDetailType } from '@/type/problem';
+import { getProblemDetail } from '@/apis/get';
 
 // util
-import { fetchProblemDataById } from '@/util/problem';
 
 const Submit = () => {
   const [code, setCode] = useState<string>('');
@@ -18,14 +19,17 @@ const Submit = () => {
   // 캐싱 데이터 사용 (없을 경우 queryFn 적용)
   const { data } = useQuery({
     queryKey: ['problemInfo', { problemId: Number(problemId) }],
-    queryFn: async () => await fetchProblemDataById(Number(problemId)),
+    queryFn: async () => {
+      const res = await getProblemDetail<ProblemDetailType>(Number(problemId));
+      return res.data;
+    },
     staleTime: Infinity,
   });
 
   useEffect(() => {
     const getFirstValue = () => {
       if (isStart && data !== undefined) {
-        const templateStr = data?.problemInfo.template?.join('');
+        const templateStr = data?.template;
         setIsStart(false);
         setCode(templateStr);
       }
@@ -35,7 +39,7 @@ const Submit = () => {
 
   return (
     <div>
-      <div className={CodeInputWrapper}>
+      {/* <div className={CodeInputWrapper}>
         <AceEditor
           className={CodeInput}
           placeholder="code input"
@@ -54,7 +58,7 @@ const Submit = () => {
           editorProps={{ $blockScrolling: true }}
           width="800px"
         />
-      </div>
+      </div> */}
     </div>
   );
 };

--- a/src/pages/submit/Submit.tsx
+++ b/src/pages/submit/Submit.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
-// import AceEditor from 'react-ace';
-// import 'ace-builds/src-noconflict/mode-typescript';
-// import 'ace-builds/src-noconflict/theme-tomorrow';
+import AceEditor from 'react-ace';
+import 'ace-builds/src-noconflict/mode-typescript';
+import 'ace-builds/src-noconflict/theme-tomorrow';
 
-// import { CodeInput, CodeInputWrapper } from './Submit.css';
+import { CodeInput, CodeInputWrapper } from './Submit.css';
 import { ProblemDetailType } from '@/type/problem';
 import { getProblemDetail } from '@/apis/get';
 
@@ -30,6 +30,7 @@ const Submit = () => {
     const getFirstValue = () => {
       if (isStart && data !== undefined) {
         const templateStr = data?.template;
+        console.log(data);
         setIsStart(false);
         setCode(templateStr);
       }
@@ -39,7 +40,7 @@ const Submit = () => {
 
   return (
     <div>
-      {/* <div className={CodeInputWrapper}>
+      <div className={CodeInputWrapper}>
         <AceEditor
           className={CodeInput}
           placeholder="code input"
@@ -58,7 +59,7 @@ const Submit = () => {
           editorProps={{ $blockScrolling: true }}
           width="800px"
         />
-      </div> */}
+      </div>
     </div>
   );
 };

--- a/src/pages/submit/Submit.tsx
+++ b/src/pages/submit/Submit.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'react-router-dom';
 // import 'ace-builds/src-noconflict/mode-typescript';
 // import 'ace-builds/src-noconflict/theme-tomorrow';
 
-import { CodeInput, CodeInputWrapper } from './Submit.css';
+// import { CodeInput, CodeInputWrapper } from './Submit.css';
 import { ProblemDetailType } from '@/type/problem';
 import { getProblemDetail } from '@/apis/get';
 

--- a/src/type/problem.ts
+++ b/src/type/problem.ts
@@ -27,3 +27,25 @@ export interface MainLevel {
   level: Level;
   count: number;
 }
+
+// API 전용
+export interface TestCasesType {
+  case: string;
+  type: string;
+}
+
+export interface ProblemDetailType {
+  message: string;
+  data: {
+    createdAt: string;
+    description: string;
+    id: number;
+    language: string;
+    level: Level;
+    number: number;
+    template: string;
+    title: string;
+    updatedAt: string;
+    testCase: TestCasesType[];
+  };
+}

--- a/src/type/problem.ts
+++ b/src/type/problem.ts
@@ -1,32 +1,32 @@
 export type Level = 'warm-up' | 'easy' | 'medium' | 'hard' | 'extreme';
 
-// 목데이터 전용으로 임시 생성.
-export interface ProblemInfoType {
-  problemId: number;
-  problemTitle: string;
-  problemDescription: string;
-  example: string[];
-  template: string[];
-  testCases: string[];
-  isSolved: boolean;
-}
+// // 목데이터 전용으로 임시 생성.
+// export interface ProblemInfoType {
+//   problemId: number;
+//   problemTitle: string;
+//   problemDescription: string;
+//   example: string[];
+//   template: string[];
+//   testCases: string[];
+//   isSolved: boolean;
+// }
 
 // export type MainProblem = Pick<ProblemInfoType, 'problemId' | 'problemTitle'> & {
 //   isSolved?: boolean;
 // };
 
-export interface MainProblem {
-  'warm-up': ProblemInfoType[];
-  easy: ProblemInfoType[];
-  medium: ProblemInfoType[];
-  hard: ProblemInfoType[];
-  extreme: ProblemInfoType[];
-}
+// export interface MainProblem {
+//   'warm-up': ProblemInfoType[];
+//   easy: ProblemInfoType[];
+//   medium: ProblemInfoType[];
+//   hard: ProblemInfoType[];
+//   extreme: ProblemInfoType[];
+// }
 
-export interface MainLevel {
-  level: Level;
-  count: number;
-}
+// export interface MainLevel {
+//   level: Level;
+//   count: number;
+// }
 
 // API 전용
 export interface TestCasesType {

--- a/src/util/problem.ts
+++ b/src/util/problem.ts
@@ -1,5 +1,4 @@
-import { getProblems } from '@/apis/get';
-import { Level, MainProblem } from '@/type/problem';
+import { ProblemDetailType } from '@/type/problem';
 
 // "problem/", "submit/"" URL 판별
 export const checkURL = (pathname: string) => {
@@ -7,15 +6,25 @@ export const checkURL = (pathname: string) => {
   return pattern.test(pathname);
 };
 
-export const getProblemDataById = (data: MainProblem, targetId: number) => {
-  for (const i in data) {
-    const key = i as Level;
-    const filterResult = data[key].filter((i) => i.problemId === targetId);
-    if (filterResult.length !== 0) return { problemDiff: key, problemInfo: filterResult[0] };
-  }
+// data.description의 README에서 문제 설명 부분 추출
+export const extractDescription = (readmeString: string) => {
+  const startIndex = readmeString.indexOf('<!--info-header-end-->');
+  const leftString = readmeString.slice(startIndex + '<!--info-header-end-->'.length);
+  const target = leftString.match(/(.+?)\n\n/);
+  const description = target !== null ? target[1].trim() : '';
+  return description;
 };
 
-export const fetchProblemDataById = async (problemId: number) => {
-  const res: MainProblem = await getProblems();
-  return getProblemDataById(res, problemId);
+// data.description의 README에서 문제 예시 추출
+export const extractExample = (readmeString: string) => {
+  const startIndex = readmeString.indexOf('<!--info-header-end-->');
+  const leftString = readmeString.slice(startIndex + '<!--info-header-end-->'.length);
+  const target = leftString.match(/```ts([\s\S]*?)```/);
+  const exampleCode = target !== null ? target[1].trim() : '';
+  return exampleCode;
+};
+
+// 테스트케이스 문자열 반환
+export const extractTestCases = (arr: ProblemDetailType['data']['testCase']) => {
+  return arr.map((i) => i.case).join('\n\n');
 };


### PR DESCRIPTION
### 💁‍♂️ PR 개요

문제 제출 페이지의 답안 작성 섹션의 MSW로직을 백엔드 API를 사용하는 로직으로 변경합니다
- #47 

<br/>

### 📝 변경 사항

- 답안 작성 섹션을 기존에 MSW를 사용하던 로직에서 백엔드 API를 사용하는 로직으로 수정 합니다
<br/>

### 📷 스크린 샷 (선택)

![image](https://github.com/type-challenges-online-judge/toj-fe/assets/78631876/a6031fea-c8e1-4c8a-84a2-f530afc43c86)


<br/>

### 🗣 리뷰어한테 할 말 (선택)

저도 몰랐는데 문제 정보 페이지에서 백엔드 API를 적용하는 과정에서 useQuery의 queryFn로직이나 각종 타입들을 
이미 다 변경을 해 두어서 제출 페이지에서는 변경할게 없었네요..ㅎ

<br/>

### 🧪 테스트 범위 (선택)

close #47 