### PR TITLE
✨ [feat]: 제출 목록 데이터 생성 및 해당 타입 선언

### DIFF
--- a/src/apis/problem.ts
+++ b/src/apis/problem.ts
@@ -1,7 +1,8 @@
+import { SubmitType } from '@/type/status';
 import axios from 'axios';
 
-export const submitAnswer = async (code: string) => {
-  const res = await axios.post('/submit', code, {
+export const submitAnswer = async (submitData: SubmitType) => {
+  const res = await axios.post('/submit', submitData, {
     headers: {
       'Content-Type': 'application/json',
     },

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -797,7 +797,8 @@ export const handlers = [
     return await res(ctx.status(200), ctx.json(submitLogData));
   }),
   rest.post<SubmitType>('/submit', async (req, res, ctx) => {
-    submitLogData.push(req.body);
+    const jsonData = await req.json();
+    submitLogData.push(jsonData);
     return await res(ctx.status(201));
   }),
 ];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,3 +1,4 @@
+import { SubmitType } from '@/type/status';
 import { rest } from 'msw';
 
 // mock data
@@ -643,15 +644,160 @@ const problemData = {
   ],
 };
 
-const submitData = [];
+const submitLogData = [
+  {
+    userId: '123',
+    problemId: 172,
+    submitNumber: 2,
+    accuracyScore: 100,
+    validate: 100,
+    codeLength: 324, // Byte
+    sumbitDate: '2023-09-13T14:12:57',
+    code: 'type First<T extends any[]> = T extends [] ? never : T[0]',
+  },
+  {
+    userId: '456',
+    problemId: 172,
+    submitNumber: 3,
+    accuracyScore: 0,
+    validate: 0,
+    codeLength: 754, // Byte
+    sumbitDate: '2023-09-13T14:12:57',
+    code: 'type First<T extends any[]> = T extends [] ? never : T[0]',
+  },
+  {
+    userId: '456',
+    problemId: 172,
+    submitNumber: 28,
+    accuracyScore: 88,
+    validate: 80,
+    codeLength: 241, // Byte
+    sumbitDate: '2023-09-13T14:12:57',
+    code: 'type First<T extends any[]> = T extends [] ? never : T[0]',
+  },
+  {
+    userId: '123',
+    problemId: 243,
+    submitNumber: 2,
+    accuracyScore: 100,
+    validate: 100,
+    codeLength: 324, // Byte
+    sumbitDate: '2023-09-13T14:12:57',
+    code: 'type First<T extends any[]> = T extends [] ? never : T[0]',
+  },
+  {
+    userId: '789',
+    problemId: 243,
+    submitNumber: 52,
+    accuracyScore: 100,
+    validate: 100,
+    codeLength: 431, // Byte
+    sumbitDate: '2023-09-13T14:12:57',
+    code: 'type First<T extends any[]> = T extends [] ? never : T[0]',
+  },
+
+  {
+    userId: '123',
+    problemId: 174,
+    submitNumber: 2,
+    accuracyScore: 100,
+    validate: 100,
+    codeLength: 324, // Byte
+    sumbitDate: '2023-09-13T14:12:57',
+    code: 'type First<T extends any[]> = T extends [] ? never : T[0]',
+  },
+  {
+    userId: '789',
+    problemId: 174,
+    submitNumber: 598,
+    accuracyScore: 100,
+    validate: 75,
+    codeLength: 164, // Byte
+    sumbitDate: '2023-09-13T14:12:57',
+    code: 'type First<T extends any[]> = T extends [] ? never : T[0]',
+  },
+  {
+    userId: '101112',
+    problemId: 174,
+    submitNumber: 75,
+    accuracyScore: 100,
+    validate: 100,
+    codeLength: 572, // Byte
+    sumbitDate: '2023-09-13T14:12:57',
+    code: 'type First<T extends any[]> = T extends [] ? never : T[0]',
+  },
+  {
+    userId: '123',
+    problemId: 201,
+    submitNumber: 2,
+    accuracyScore: 100,
+    validate: 100,
+    codeLength: 324, // Byte
+    sumbitDate: '2023-09-13T14:12:57',
+    code: 'type First<T extends any[]> = T extends [] ? never : T[0]',
+  },
+  {
+    userId: '0000',
+    problemId: 201,
+    submitNumber: 913,
+    accuracyScore: 50,
+    validate: 50,
+    codeLength: 29, // Byte
+    sumbitDate: '2023-09-13T14:12:57',
+    code: 'type First<T extends any[]> = T extends [] ? never : T[0]',
+  },
+  {
+    userId: '123',
+    problemId: 220,
+    submitNumber: 2,
+    accuracyScore: 100,
+    validate: 100,
+    codeLength: 324, // Byte
+    sumbitDate: '2023-09-13T14:12:57',
+    code: 'type First<T extends any[]> = T extends [] ? never : T[0]',
+  },
+  {
+    userId: '131415',
+    problemId: 220,
+    submitNumber: 9,
+    accuracyScore: 33,
+    validate: 10,
+    codeLength: 64, // Byte
+    sumbitDate: '2023-09-13T14:12:57',
+    code: 'type First<T extends any[]> = T extends [] ? never : T[0]',
+  },
+  {
+    userId: '131415',
+    problemId: 220,
+    submitNumber: 9,
+    accuracyScore: 100,
+    validate: 100,
+    codeLength: 64, // Byte
+    sumbitDate: '2023-09-13T14:12:57',
+    code: 'type First<T extends any[]> = T extends [] ? never : T[0]',
+  },
+  {
+    userId: '123',
+    problemId: 235,
+    submitNumber: 2,
+    accuracyScore: 40,
+    validate: 0,
+    codeLength: 324, // Byte
+    sumbitDate: '2023-09-13T14:12:57',
+    code: 'type First<T extends any[]> = T extends [] ? never : T[0]',
+  },
+];
 
 // API
 export const handlers = [
   rest.get('/problems', async (req, res, ctx) => {
     return await res(ctx.status(200), ctx.json(problemData));
   }),
-  rest.post('/submit', async (req, res, ctx) => {
-    submitData.push(req.body);
+  rest.get('/submit', async (req, res, ctx) => {
+    return await res(ctx.status(200), ctx.json(submitLogData));
+  }),
+  rest.post<SubmitType>('/submit', async (req, res, ctx) => {
+    submitLogData.push(req.body);
     return await res(ctx.status(201));
   }),
 ];

--- a/src/pages/submit/Submit.tsx
+++ b/src/pages/submit/Submit.tsx
@@ -11,6 +11,7 @@ import { BasicButton } from '@/components';
 import { ProblemDetailType } from '@/type/problem';
 
 import { CodeInput, CodeInputWrapper } from './Submit.css';
+import { SubmitType } from '@/type/status';
 
 const Submit = () => {
   const [code, setCode] = useState<string>('');
@@ -30,7 +31,7 @@ const Submit = () => {
   });
 
   const { mutate: submitAnswerMutation } = useMutation(
-    async (code: string) => await submitAnswer(code),
+    async (submitData: SubmitType) => await submitAnswer(submitData),
     {
       onSuccess() {},
       onError: (err) => {
@@ -40,11 +41,25 @@ const Submit = () => {
   );
 
   const submitAnswerOnClick = () => {
-    submitAnswerMutation(code, {
-      onSuccess: async () => {
-        navigate(`/status?result_id=-1&problem_id=${problemId}&user_id=minh0518&mine=true`);
-      },
-    });
+    if (problemId !== undefined) {
+      submitAnswerMutation(
+        {
+          userId: '123',
+          problemId: Number(problemId),
+          submitNumber: Math.floor(Math.random() * 1000) + 1,
+          accuracyScore: Math.floor(Math.random() * 101),
+          validate: Math.floor(Math.random() * 1001),
+          codeLength: Math.floor(Math.random() * 1000),
+          sumbitDate: '2023-09-13T14:12:57',
+          code,
+        },
+        {
+          onSuccess: async () => {
+            navigate(`/status?result_id=-1&problem_id=${problemId}&user_id=minh0518&mine=true`);
+          },
+        },
+      );
+    }
   };
 
   useEffect(() => {

--- a/src/type/status.ts
+++ b/src/type/status.ts
@@ -1,0 +1,11 @@
+// 목데이터 전용으로 임시 생성.
+export interface SubmitType {
+  userId: string;
+  problemId: number;
+  submitNumber: number;
+  accuracyScore: number;
+  validate: number;
+  codeLength: number; // Byte
+  sumbitDate: string;
+  code: string;
+}


### PR DESCRIPTION
### 💁‍♂️ PR 개요

제출 현황 페이지에 사용되는 MSW 데이터를 생성합니다
- #54 

<br/>

### 📝 변경 사항

- 제출 현황 페이지에 사용되는 MSW 데이터 생성
- 해당 데이터 타입 생성
- 기존 제출하기 페이지에서 전송하던 데이터 형식 수정 (MSW 데이터 형식에 맞게)

<br/>

### 📷 스크린 샷 (선택)

![image](https://github.com/type-challenges-online-judge/toj-fe/assets/78631876/462a29ba-5273-4380-8187-07e608c4348c)


<br/>

### 🗣 리뷰어한테 할 말 (선택)


<br/>

### 🧪 테스트 범위 (선택)

close #54 