### PR TITLE
♻️[refactor]: 백엔드 API를 기반으로 메인페이지 로직 수정

### DIFF
--- a/src/apis/problem.ts
+++ b/src/apis/problem.ts
@@ -1,4 +1,9 @@
 import axios from 'axios';
+import { API } from './instance';
+
+export const problemApi = {
+  getProblems: async () => await API.get('/api/problem'),
+};
 
 export const submitAnswer = async (code: string) => {
   const res = await axios.post('/submit', code, {

--- a/src/components/core/button/MainProblemButton.css.ts
+++ b/src/components/core/button/MainProblemButton.css.ts
@@ -10,7 +10,7 @@ export const ProblemButtonStyle = style({
     '&.true': {
       backgroundColor: '#CCCAC8',
     },
-    '&.warm-up': {
+    '&.warm': {
       backgroundColor: '#0F8383',
     },
     '&.easy': {

--- a/src/components/core/button/ProblemButton.css.ts
+++ b/src/components/core/button/ProblemButton.css.ts
@@ -21,7 +21,7 @@ export const ProblemDiffAndId = style({
   color: 'white',
 
   selectors: {
-    '&.warm-up': {
+    '&.warm': {
       backgroundColor: '#0F8383',
     },
     '&.easy': {

--- a/src/components/widget/main/LevelLabel.css.ts
+++ b/src/components/widget/main/LevelLabel.css.ts
@@ -18,7 +18,7 @@ export const CountStyle = style({
   padding: '4px 8px',
 
   selectors: {
-    '&.warm-up': {
+    '&.warm': {
       backgroundColor: '#0F8383',
     },
     '&.easy': {

--- a/src/components/widget/main/MainProblems.tsx
+++ b/src/components/widget/main/MainProblems.tsx
@@ -1,5 +1,9 @@
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useState } from 'react';
+
+import { MainProblemButton, LevelLabel } from '@/components';
+import { useGetProblems } from '@/hooks/queries/problem';
+import { Level, ProblemType, ProblemsType } from '@/type/problem';
 
 import {
   MainLevelsWrapperStyle,
@@ -7,57 +11,67 @@ import {
   MainProblemsWrapperStyle,
 } from './MainProblems.css';
 
-// import { LevelLabel, MainProblemButton } from '@/components';
-// import { MainLevel, MainProblem } from '@/type/problem';
-// import { MAIN_LEVELS } from '@/data/Problems';
-
-// 기존 API로직 때문에 에러가 발생하게 되므로 민지님이 추후 수정해 주세요
 const MainProblems = () => {
+  const [problems, setProblems] = useState<ProblemsType>();
+  const { data: { data: unsortedProblems = null } = {} } = useGetProblems();
+
   const navigate = useNavigate();
 
-  // const [problemData, setProblemData] = useState<MainProblem | null>(null);
+  const moveProblemDetail = (id: number) => {
+    navigate(`/problem/${id}`);
+  };
 
-  // useEffect(() => {
-  //   const getProblemData = async () => {
-  //     try {
-  //       const res = await getProblems<MainProblem>();
-  //       setProblemData(res);
-  //     } catch (e) {
-  //       console.error(e);
-  //     }
-  //   };
-  //   getProblemData();
-  // }, []);
+  useEffect(() => {
+    if (unsortedProblems != null) {
+      const sortedProblems: ProblemsType = {
+        warm: [],
+        easy: [],
+        medium: [],
+        hard: [],
+        extreme: [],
+      };
+
+      for (const unsortedProblem of unsortedProblems.data) {
+        sortedProblems[unsortedProblem.level as Level].push({
+          id: unsortedProblem.id,
+          title: unsortedProblem.title,
+          number: unsortedProblem.number,
+        });
+      }
+
+      setProblems(sortedProblems);
+    }
+  }, [unsortedProblems]);
 
   return (
-    <div className={MainProblemsWrapperStyle}>
-      {/* {MAIN_LEVELS.map((levelLabel: MainLevel, index: number) => {
-        return (
-          <div key={index} className={MainLevelsWrapperStyle}>
-            <LevelLabel level={levelLabel.level} count={levelLabel.count} />
-            {problemData !== null && (
+    problems != null && (
+      <div className={MainProblemsWrapperStyle}>
+        {Object.keys(problems).map((level: string, index: number) => {
+          return (
+            <div key={index} className={MainLevelsWrapperStyle}>
+              <LevelLabel level={level as Level} count={problems[level as Level].length} />
               <div className={MainLevelProblemsWrapperStyle}>
-                {problemData[levelLabel.level].map((problem: ProblemInfoType, idx: number) => {
+                {problems[level as Level].map((problem: ProblemType, idx: number) => {
                   return (
                     <div key={idx}>
                       <MainProblemButton
-                        id={problem.problemId}
-                        text={problem.problemTitle}
-                        level={levelLabel.level}
-                        isSolved={problem.isSolved ?? false}
+                        id={problem.number}
+                        text={problem.title}
+                        level={level as Level}
+                        isSolved={false}
                         _onClick={() => {
-                          navigate(`/problem/${problem.problemId}`);
+                          moveProblemDetail(problem.id);
                         }}
                       />
                     </div>
                   );
                 })}
               </div>
-            )}
-          </div>
-        );
-      })} */}
-    </div>
+            </div>
+          );
+        })}
+      </div>
+    )
   );
 };
 

--- a/src/components/widget/probleminfo/ProblemInfo.css.ts
+++ b/src/components/widget/probleminfo/ProblemInfo.css.ts
@@ -9,7 +9,7 @@ const ProblemDiffFont = style({
   marginLeft: '30px',
 });
 export const ProblemDiffStyle = {
-  'warm-up': style([ProblemDiffFont, { color: '#0F8383' }]),
+  warm: style([ProblemDiffFont, { color: '#0F8383' }]),
   easy: style([ProblemDiffFont, { color: '#7BA918' }]),
   medium: style([ProblemDiffFont, { color: '#D49228' }]),
   hard: style([ProblemDiffFont, { color: '#D74640' }]),

--- a/src/hooks/queries/problem.ts
+++ b/src/hooks/queries/problem.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { problemApi } from '@/apis/problem';
+
+export const useGetProblems = <T>(options?: T) => {
+  return useQuery(['getProblems'], async () => await problemApi.getProblems(), {
+    retry: 0,
+    onError: (err) => {
+      console.log(err);
+    },
+    staleTime: 36000000,
+    cacheTime: Infinity,
+    ...options,
+  });
+};

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -2,7 +2,7 @@ import { rest } from 'msw';
 
 // mock data
 const problemData = {
-  'warm-up': [
+  warm: [
     {
       problemId: 13,
       problemTitle: 'Pick',

--- a/src/type/problem.ts
+++ b/src/type/problem.ts
@@ -1,4 +1,34 @@
-export type Level = 'warm-up' | 'easy' | 'medium' | 'hard' | 'extreme';
+export type Level = 'warm' | 'easy' | 'medium' | 'hard' | 'extreme';
+
+export type ProblemsType = Record<Level, ProblemType[]>;
+
+export interface ProblemType {
+  id: number;
+  title: string;
+  number: number;
+}
+
+// API 전용
+export interface TestCasesType {
+  case: string;
+  type: string;
+}
+
+export interface ProblemDetailType {
+  message: string;
+  data: {
+    createdAt: string;
+    description: string;
+    id: number;
+    language: string;
+    level: Level;
+    number: number;
+    template: string;
+    title: string;
+    updatedAt: string;
+    testCase: TestCasesType[];
+  };
+}
 
 // // 목데이터 전용으로 임시 생성.
 // export interface ProblemInfoType {
@@ -27,25 +57,3 @@ export type Level = 'warm-up' | 'easy' | 'medium' | 'hard' | 'extreme';
 //   level: Level;
 //   count: number;
 // }
-
-// API 전용
-export interface TestCasesType {
-  case: string;
-  type: string;
-}
-
-export interface ProblemDetailType {
-  message: string;
-  data: {
-    createdAt: string;
-    description: string;
-    id: number;
-    language: string;
-    level: Level;
-    number: number;
-    template: string;
-    title: string;
-    updatedAt: string;
-    testCase: TestCasesType[];
-  };
-}


### PR DESCRIPTION
### 💁‍♂️ PR 개요

메인페이지 로직 수정했습니다.

- #53 

<br/>

### 📝 변경 사항

기존에 사용한 MSW 대신 백엔드 API를 연결해서 문제 리스트를 불러왔습니다.

<br/>

### 📷 스크린 샷 (선택)
![image](https://github.com/type-challenges-online-judge/toj-fe/assets/46989954/ec808a8b-c711-46b7-a407-143fec9c536b)

<br/>

### 🗣 리뷰어한테 할 말 (선택)

<br/>

### 🧪 테스트 범위 (선택)

close #53 
