### PR TITLE
✨ [feat]: 제출하기 버튼 클릭 후 채점 로직 구현

### DIFF
--- a/src/apis/problem.ts
+++ b/src/apis/problem.ts
@@ -9,7 +9,7 @@ export const problemApi = {
     return await API.get<T>(`/api/problem/detail/${id}`);
   },
   postSumbitCode: async (id: string, codeStr: string) => {
-    const res = await API.post(`/api/problem/submit/${id}`, { code: codeStr });
+    const res = await API.post(`/api/submit/${id}`, { code: codeStr });
     return res;
   },
 };

--- a/src/apis/problem.ts
+++ b/src/apis/problem.ts
@@ -8,6 +8,10 @@ export const problemApi = {
   getProblemDetail: async <T>(id: number): Promise<AxiosResponse<T>> => {
     return await API.get<T>(`/api/problem/detail/${id}`);
   },
+  postSumbitCode: async (id: string, codeStr: string) => {
+    const res = await API.post(`/api/problem/submit/${id}`, { code: codeStr });
+    return res;
+  },
 };
 
 // MSW

--- a/src/components/core/button/ProblemMenuButtons.tsx
+++ b/src/components/core/button/ProblemMenuButtons.tsx
@@ -5,6 +5,7 @@ import { Level } from '@/type/problem';
 import { MenuButton, ProblemDiffAndId } from './ProblemButton.css';
 
 interface ProblemMenuButtonsProps {
+  isAuth?: boolean;
   problemDiff?: Level;
   problemId?: number;
   text: string;
@@ -12,13 +13,14 @@ interface ProblemMenuButtonsProps {
 }
 
 const ProblemMenuButtons = ({
+  isAuth,
   problemDiff,
   problemId,
   text,
   _onClick,
 }: ProblemMenuButtonsProps) => {
   return (
-    <button onClick={_onClick} className={MenuButton}>
+    <button onClick={_onClick} className={MenuButton} disabled={isAuth === false}>
       {problemDiff !== undefined && problemId !== undefined && (
         <div className={`${ProblemDiffAndId} ${problemDiff}`}>
           <span>{problemId}</span>

--- a/src/components/widget/problemmenus/ProblemMenus.tsx
+++ b/src/components/widget/problemmenus/ProblemMenus.tsx
@@ -12,6 +12,8 @@ import { SingleButton, ButtonList, ProblemMunusWrapperStyle } from './ProblemMen
 
 // const
 import { PAGE_URL } from '@/config/path';
+import { useUserInfo } from '@/stores/useUserInfoStore';
+import { useIsAuth } from '@/stores/useAuthStore';
 
 interface ProblemMenusProps {
   problemDetail: ProblemDetailType['data'];
@@ -20,13 +22,19 @@ interface ProblemMenusProps {
 const ProblemMenus = ({ problemDetail }: ProblemMenusProps) => {
   const navigate = useNavigate();
 
-  // 내 제출
-  // https://localhost:3000/status?result_id=1&problem_id=4&snsId=123&mine=true
-  // problem_id , snsId , result_id=1(1이면 맞은 문제, -1이면 모두 ) , mine=true
+  const isAuth = useIsAuth();
+  const userInfo = useUserInfo();
 
-  // 정답
-  // https://localhost:3000/status?result_id=1&problem_id=4&snsId=123&mine=false
-  // problem_id , snsId , result_id=1 , mine=false
+  /**
+   *
+   * 제출 현황 페이지 이동시 사용되는 URL 명세입니다.
+   * https://localhost:3000/status?result_id=1&problem_id=172&[snsId=123]
+   * @route GET /status
+   * @param {string} query.result_id -  1:정답 , 2:오답 , 3:정확성 , -1:전부
+   * @param {number} query.problem_id - 문제의 ID를 나타냅니다.
+   * @param {string} query.snsId - GITHUB의 유저ID값을 의미합니다 (존재할 경우 내 제출, 없을 경우 모든 유저 제출)
+   * @returns {Object} Response object
+   */
 
   return (
     <div className={ProblemMunusWrapperStyle}>
@@ -44,6 +52,7 @@ const ProblemMenus = ({ problemDetail }: ProblemMenusProps) => {
 
         <li className={SingleButton}>
           <ProblemMenuButtons
+            isAuth={isAuth}
             text="제출하기"
             _onClick={() => {
               navigate(`/${PAGE_URL.Submit}/${problemDetail.id}`);
@@ -54,18 +63,17 @@ const ProblemMenus = ({ problemDetail }: ProblemMenusProps) => {
           <ProblemMenuButtons
             text="답안 보기"
             _onClick={() => {
-              navigate(
-                `/${PAGE_URL.Status}?result_id=1&problem_id=${problemDetail.id}&snsId=123&mine=false`,
-              );
+              navigate(`/${PAGE_URL.Status}?result_id=1&problem_id=${problemDetail.id}`);
             }}
           />
         </li>
         <li className={`${SingleButton} isLast`}>
           <ProblemMenuButtons
+            isAuth={isAuth}
             text="내 제출"
             _onClick={() => {
               navigate(
-                `/${PAGE_URL.Status}?result_id=1&problem_id=${problemDetail.id}&snsId=123&mine=true`,
+                `/${PAGE_URL.Status}?result_id=-1&problem_id=${problemDetail.id}&snsId=${userInfo.snsId}`,
               );
             }}
           />

--- a/src/components/widget/problemmenus/ProblemMenus.tsx
+++ b/src/components/widget/problemmenus/ProblemMenus.tsx
@@ -28,7 +28,7 @@ const ProblemMenus = ({ problemDetail }: ProblemMenusProps) => {
   /**
    *
    * 제출 현황 페이지 이동시 사용되는 URL 명세입니다.
-   * https://localhost:3000/status?result_id=1&problem_id=172&[snsId=123]
+   * https://localhost:3000/status?result_id=1&problem_id=172&[sns_id=123]
    * @route GET /status
    * @param {string} query.result_id -  1:정답 , 2:오답 , 3:정확성 , -1:전부
    * @param {number} query.problem_id - 문제의 ID를 나타냅니다.
@@ -73,7 +73,7 @@ const ProblemMenus = ({ problemDetail }: ProblemMenusProps) => {
             text="내 제출"
             _onClick={() => {
               navigate(
-                `/${PAGE_URL.Status}?result_id=-1&problem_id=${problemDetail.id}&snsId=${userInfo.snsId}`,
+                `/${PAGE_URL.Status}?result_id=-1&problem_id=${problemDetail.id}&sns_id=${userInfo.snsId}`,
               );
             }}
           />

--- a/src/components/widget/problemsubmit/ProblemSubmit.css.ts
+++ b/src/components/widget/problemsubmit/ProblemSubmit.css.ts
@@ -1,0 +1,14 @@
+import { style } from '@vanilla-extract/css';
+
+export const CodeInputWrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-end',
+  justifyContent: 'center',
+  margin: '100px 0',
+});
+
+export const CodeInput = style({
+  marginBottom: '10px',
+  border: '1px solid #F4F6F8',
+});

--- a/src/components/widget/problemsubmit/ProblemSubmit.tsx
+++ b/src/components/widget/problemsubmit/ProblemSubmit.tsx
@@ -30,7 +30,7 @@ const ProblemSubmit = () => {
     },
     {
       onSuccess: (data) => {
-        navigate(`/status?result_id=-1&problem_id=${problemId}&snsId=${useInfo.snsId}`);
+        navigate(`/status?result_id=-1&problem_id=${problemId}&sns_id=${useInfo.snsId}`);
       },
       onError: (err) => {
         console.error(err);

--- a/src/components/widget/problemsubmit/ProblemSubmit.tsx
+++ b/src/components/widget/problemsubmit/ProblemSubmit.tsx
@@ -1,0 +1,84 @@
+import { useGetProblemDetail } from '@/hooks/queries/problem';
+import { useUserInfo } from '@/stores/useUserInfoStore';
+import { ProblemDetailType } from '@/type/problem';
+import { useMutation } from '@tanstack/react-query';
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import AceEditor from 'react-ace';
+import 'ace-builds/src-noconflict/mode-typescript';
+import 'ace-builds/src-noconflict/theme-tomorrow';
+import { BasicButton } from '@/components';
+import { CodeInput, CodeInputWrapper } from './ProblemSubmit.css';
+import { problemApi } from '@/apis/problem';
+
+const ProblemSubmit = () => {
+  const [code, setCode] = useState<string>('');
+  const [isStart, setIsStart] = useState(true);
+  const { problemId } = useParams();
+  const navigate = useNavigate();
+  const useInfo = useUserInfo();
+
+  // 캐싱 데이터 사용 (없을 경우 queryFn 적용)
+  const { data: { data: problemDetailData = null } = {} } = useGetProblemDetail<ProblemDetailType>(
+    Number(problemId),
+  );
+
+  const { mutate: submitAnswerMutation } = useMutation(
+    ['submit', problemId],
+    async () => {
+      return await problemApi.postSumbitCode(problemId as string, code);
+    },
+    {
+      onSuccess: (data) => {
+        navigate(`/status?result_id=-1&problem_id=${problemId}&snsId=${useInfo.snsId}`);
+      },
+      onError: (err) => {
+        console.error(err);
+      },
+    },
+  );
+  const submitAnswerOnClick = async () => {
+    if (problemId !== undefined) submitAnswerMutation();
+  };
+
+  useEffect(() => {
+    const getFirstValue = () => {
+      if (isStart && problemDetailData !== null) {
+        const templateStr = problemDetailData.template;
+        setIsStart(false);
+        setCode(templateStr);
+      }
+    };
+    getFirstValue();
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [problemDetailData]);
+  return (
+    <div>
+      <div className={CodeInputWrapper}>
+        <AceEditor
+          className={CodeInput}
+          placeholder="code input"
+          mode="typescript"
+          theme="tomorrow"
+          onChange={(value) => {
+            setCode(value);
+          }}
+          name="typescript-editor"
+          fontSize={16}
+          value={code}
+          showPrintMargin={true}
+          showGutter={true}
+          highlightActiveLine={true}
+          tabSize={2}
+          editorProps={{ $blockScrolling: true }}
+          width="100%"
+        />
+
+        <BasicButton text="제출하기" _onClick={submitAnswerOnClick} />
+      </div>
+    </div>
+  );
+};
+
+export default ProblemSubmit;

--- a/src/components/widget/problemsubmit/index.ts
+++ b/src/components/widget/problemsubmit/index.ts
@@ -1,0 +1,1 @@
+export { default as ProblemSubmit } from './ProblemSubmit';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,7 +10,7 @@ import axios from 'axios';
 axios.defaults.withCredentials = true;
 
 if (process.env.NODE_ENV === 'development') {
-  // worker.start();
+  worker.start();
 }
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,7 +10,7 @@ import axios from 'axios';
 axios.defaults.withCredentials = true;
 
 if (process.env.NODE_ENV === 'development') {
-  worker.start();
+  // worker.start();
 }
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/src/pages/status/Status.tsx
+++ b/src/pages/status/Status.tsx
@@ -18,24 +18,8 @@ const Status = () => {
   // const [resultId, problemId, snsId] = [
   //   Number(queryParams.get('result_id')),
   //   Number(queryParams.get('problem_id')),
-  //   Number(queryParams.get('snsId')),
+  //   Number(queryParams.get('sns_id')),
   // ];
-
-  // MSW 메소드 사용 중단
-  // useEffect(() => {
-  //   const getSubmitStatus = async () => {
-  //     await axios.get('status', {
-  //       params: {
-  //         result_id: resultId,
-  //         problem_id: problemId,
-  //         snsId,
-  //       },
-  //     });
-  //   };
-  //   getSubmitStatus();
-
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, []);
 
   return <div>문제 기록 페이지 (내 제출 ,정답 보기)</div>;
 };

--- a/src/pages/status/Status.tsx
+++ b/src/pages/status/Status.tsx
@@ -1,33 +1,41 @@
-import React, { useEffect } from 'react';
-import axios from 'axios';
-import { useLocation } from 'react-router-dom';
+import React from 'react';
+
+/**
+ *
+ * 제출 현황 페이에서 사용되는 URL 명세입니다.
+ * https://localhost:3000/status?result_id=1&problem_id=172&[snsId=123]
+ * @route GET /status
+ * @param {string} query.result_id -  1:정답 , 2:오답 , 3:정확성 , -1:전부
+ * @param {number} query.problem_id - 문제의 ID를 나타냅니다.
+ * @param {string} query.snsId - GITHUB의 유저ID값을 의미합니다 (존재할 경우 내 제출, 없을 경우 모든 유저 제출)
+ * @returns {Object} Response object
+ */
 
 const Status = () => {
-  const location = useLocation();
-  const queryParams = new URLSearchParams(location.search);
+  // const location = useLocation();
+  // const queryParams = new URLSearchParams(location.search);
 
-  const [resultId, problemId, snsId, mine] = [
-    Number(queryParams.get('result_id')),
-    Number(queryParams.get('problem_id')),
-    Number(queryParams.get('snsId')),
-    queryParams.get('mine') === 'true',
-  ];
+  // const [resultId, problemId, snsId] = [
+  //   Number(queryParams.get('result_id')),
+  //   Number(queryParams.get('problem_id')),
+  //   Number(queryParams.get('snsId')),
+  // ];
 
-  useEffect(() => {
-    const getSubmitStatus = async () => {
-      await axios.get('status', {
-        params: {
-          result_id: resultId,
-          problem_id: problemId,
-          snsId,
-          mine,
-        },
-      });
-    };
-    getSubmitStatus();
+  // MSW 메소드 사용 중단
+  // useEffect(() => {
+  //   const getSubmitStatus = async () => {
+  //     await axios.get('status', {
+  //       params: {
+  //         result_id: resultId,
+  //         problem_id: problemId,
+  //         snsId,
+  //       },
+  //     });
+  //   };
+  //   getSubmitStatus();
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, []);
 
   return <div>문제 기록 페이지 (내 제출 ,정답 보기)</div>;
 };

--- a/src/pages/submit/Submit.css.ts
+++ b/src/pages/submit/Submit.css.ts
@@ -10,5 +10,5 @@ export const CodeInputWrapper = style({
 
 export const CodeInput = style({
   marginBottom: '10px',
-  border: '1px solid black',
+  border: '1px solid #F4F6F8',
 });

--- a/src/pages/submit/Submit.tsx
+++ b/src/pages/submit/Submit.tsx
@@ -1,85 +1,10 @@
-import React, { useEffect, useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
-import { useNavigate, useParams } from 'react-router-dom';
-import AceEditor from 'react-ace';
-import 'ace-builds/src-noconflict/mode-typescript';
-import 'ace-builds/src-noconflict/theme-tomorrow';
-
-import { problemApi } from '@/apis/problem';
-import { BasicButton } from '@/components';
-
-import { CodeInput, CodeInputWrapper } from './Submit.css';
-import { useGetProblemDetail } from '@/hooks/queries/problem';
-import { ProblemDetailType } from '@/type/problem';
-import { useUserInfo } from '@/stores/useUserInfoStore';
+import { ProblemSubmit } from '@/components/widget/problemsubmit';
+import React from 'react';
 
 const Submit = () => {
-  const [code, setCode] = useState<string>('');
-  const [isStart, setIsStart] = useState(true);
-  const { problemId } = useParams();
-  const navigate = useNavigate();
-  const useInfo = useUserInfo();
-
-  // 캐싱 데이터 사용 (없을 경우 queryFn 적용)
-  const { data: { data: problemDetailData = null } = {} } = useGetProblemDetail<ProblemDetailType>(
-    Number(problemId),
-  );
-
-  const { mutate: submitAnswerMutation } = useMutation(
-    ['submit', problemId],
-    async () => {
-      return await problemApi.postSumbitCode(problemId as string, code);
-    },
-    {
-      onSuccess: (data) => {
-        navigate(`/status?result_id=-1&problem_id=${problemId}&snsId=${useInfo.snsId}`);
-      },
-      onError: (err) => {
-        console.error(err);
-      },
-    },
-  );
-  const submitAnswerOnClick = async () => {
-    if (problemId !== undefined) submitAnswerMutation();
-  };
-
-  useEffect(() => {
-    const getFirstValue = () => {
-      if (isStart && problemDetailData !== null) {
-        const templateStr = problemDetailData.template;
-        setIsStart(false);
-        setCode(templateStr);
-      }
-    };
-    getFirstValue();
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [problemDetailData]);
-
   return (
     <div>
-      <div className={CodeInputWrapper}>
-        <AceEditor
-          className={CodeInput}
-          placeholder="code input"
-          mode="typescript"
-          theme="tomorrow"
-          onChange={(value) => {
-            setCode(value);
-          }}
-          name="typescript-editor"
-          fontSize={16}
-          value={code}
-          showPrintMargin={true}
-          showGutter={true}
-          highlightActiveLine={true}
-          tabSize={2}
-          editorProps={{ $blockScrolling: true }}
-          width="100%"
-        />
-
-        <BasicButton text="제출하기" _onClick={submitAnswerOnClick} />
-      </div>
+      <ProblemSubmit />
     </div>
   );
 };

--- a/src/stores/useUserInfoStore.ts
+++ b/src/stores/useUserInfoStore.ts
@@ -17,7 +17,6 @@ export const useUserInfoStore = create(
     (set) => ({
       ...initailState,
       setUserInfoState: (userInfo: UserInfoType) => {
-        console.log(userInfo);
         set({ ...userInfo });
       },
     }),


### PR DESCRIPTION
### 💁‍♂️ PR 개요

1. 코드 제출 페이지에서 코드를 작성 후 제출하기 버튼을 누르면 진행되는 동작을 구현합니다.
2. 제출 현황 페이지에 사용되는 쿼리스트링을 수정하고 이에 의존되는 로직을 수정 합니다
- #69 

<br/>

### 📝 변경 사항

- 제출 페이지에서 코드 제출 후 진행되는 채점 로직을 구현합니다
- 제출 현황 페이지에 사용되는 쿼리스트링을 수정 합니다
    - mine 필드 삭제, snsId로 내 제출 or 전체 유저 제출 판별)
- 쿼리스트링 수정으로 인한 문제 페이지 메뉴 바 로직을 수정 합니다
    -  내 제출 목록은 snsId가 존재할 때 보여주도록 변경합니다
    -  그러므로 로그인이 되어 있지 않는다면 내 `메뉴 바의 내 제출` 버튼을 disabled 처리 합니다
    -  근데 제출하기 버튼을 누르게 되면 내 제출 목록으로 먼저 넘어가기 때문에
       (백준처럼) `메뉴 바의 제출하기` 버튼 역시 로그인 되어 있지 않는다면 disabled 처리 합니다

<br/>

### 📷 스크린 샷 (선택)

- 실제 코드 제출 후, 해당 문제에 대한 제출 결과입니다
![image](https://github.com/type-challenges-online-judge/toj-fe/assets/78631876/09cefab1-a79d-4717-b9b0-75145cc1675f)


<br>
<br>


- 로그인 기반 메뉴바 disabled 
![image](https://github.com/type-challenges-online-judge/toj-fe/assets/78631876/0feffaca-911a-48d3-96e0-3ad7ebcdacbb)


<br/>

### 🗣 리뷰어한테 할 말 (선택)


<br/>

### 🧪 테스트 범위 (선택)


close #69 