### PR TITLE
♻️ [refactor]: 메뉴바에 문제 id대신 번호 표시 , API메소드 타입 추가

### DIFF
--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -1,9 +1,9 @@
-import { AxiosError } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
 import { API } from './instance';
 
 // API
 export const loginApi = {
-  postLogin: async (gitHubAuthCode: string) => {
+  postLogin: async <T>(gitHubAuthCode: string): Promise<AxiosResponse<T> | undefined> => {
     try {
       const apiResponse = await API.post('/api/auth/login', null, {
         params: { code: gitHubAuthCode },

--- a/src/apis/problem.ts
+++ b/src/apis/problem.ts
@@ -4,12 +4,12 @@ import { API } from './instance';
 
 // API
 export const problemApi = {
-  getProblems: async () => await API.get('/api/problem'),
+  getProblems: async <T>(): Promise<AxiosResponse<T>> => await API.get<T>('/api/problem'),
   getProblemDetail: async <T>(id: number): Promise<AxiosResponse<T>> => {
     return await API.get<T>(`/api/problem/detail/${id}`);
   },
-  postSumbitCode: async (id: string, codeStr: string) => {
-    const res = await API.post(`/api/problem/submit/${id}`, { code: codeStr });
+  postSumbitCode: async <T>(id: string, codeStr: string): Promise<AxiosResponse<T>> => {
+    const res = await API.post<T>(`/api/submit/${id}`, { code: codeStr });
     return res;
   },
 };

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,11 +1,11 @@
-import { AxiosError } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
 import { API } from './instance';
 
 // API
 export const userApi = {
-  getUserInfo: async () => {
+  getUserInfo: async <T>(): Promise<AxiosResponse<T> | undefined> => {
     try {
-      const apiResponse = await API.get(`/api/user/info`);
+      const apiResponse = await API.get<T>(`/api/user/info`);
       return apiResponse;
     } catch (e) {
       if (e instanceof AxiosError) console.error(e.message);

--- a/src/components/layout/CommonLayoutWithMenus.tsx
+++ b/src/components/layout/CommonLayoutWithMenus.tsx
@@ -7,7 +7,7 @@ import { ProblemMenus } from '@/components/widget';
 // util
 import { checkURL } from '@/util/problem';
 import { useGetProblemDetail } from '@/hooks/queries/problem';
-import { ProblemDetailType } from '@/type/problem';
+import { GetProblemDetailType } from '@/type/problem';
 import { CommonLayoutStyle } from './CommonLayout.css';
 
 const CommonLayoutWithMenus = () => {
@@ -32,7 +32,7 @@ const CommonLayoutWithMenus = () => {
   }, [location.pathname, problemId]);
 
   const { data: { data: problemDetailData = null } = {} } =
-    useGetProblemDetail<ProblemDetailType>(currentProblemId);
+    useGetProblemDetail<GetProblemDetailType>(currentProblemId);
 
   return (
     <div className={CommonLayoutStyle}>

--- a/src/components/widget/common/Navbar.tsx
+++ b/src/components/widget/common/Navbar.tsx
@@ -17,6 +17,10 @@ import { GIT_HUB_LOGIN_URL } from '@/config/const';
 import { useIsAuth, useIsAuthActions } from '@/stores/useAuthStore';
 import { useUserInfoActions } from '@/stores/useUserInfoStore';
 
+// type
+import { GetUserInfoType } from '@/type/user';
+import { PostLoginResponseType } from '@/type/login';
+
 const Navbar = () => {
   const location = useLocation();
   const urlParams = new URLSearchParams(location.search);
@@ -29,7 +33,8 @@ const Navbar = () => {
 
   useEffect(() => {
     const login = async () => {
-      const response = await loginApi.postLogin(codeQueryString!);
+      const response = await loginApi.postLogin<PostLoginResponseType>(codeQueryString!);
+      console.log(response);
 
       if (response?.status === 201) {
         setIsAuthState(true);
@@ -38,8 +43,8 @@ const Navbar = () => {
         urlParams.delete('code');
         navigate(`${location.pathname}?${urlParams.toString()}`, { replace: true });
 
-        const response = await userApi.getUserInfo();
-        setUserInfoState({ userInfo: response?.data.data });
+        const response = await userApi.getUserInfo<GetUserInfoType>();
+        setUserInfoState({ userInfo: response!.data.data });
       }
     };
     if (codeQueryString !== null) login();

--- a/src/components/widget/main/MainProblems.tsx
+++ b/src/components/widget/main/MainProblems.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { MainProblemButton, LevelLabel } from '@/components';
 import { useGetProblems } from '@/hooks/queries/problem';
-import { Level, ProblemType, ProblemsType } from '@/type/problem';
+import { GetProblemListType, Level, ProblemType, ProblemsType } from '@/type/problem';
 
 import {
   MainLevelsWrapperStyle,
@@ -13,7 +13,7 @@ import {
 
 const MainProblems = () => {
   const [problems, setProblems] = useState<ProblemsType>();
-  const { data: { data: unsortedProblems = null } = {} } = useGetProblems();
+  const { data: { data: unsortedProblems = null } = {} } = useGetProblems<GetProblemListType>();
 
   const navigate = useNavigate();
 
@@ -32,7 +32,7 @@ const MainProblems = () => {
       };
 
       for (const unsortedProblem of unsortedProblems.data) {
-        sortedProblems[unsortedProblem.level as Level].push({
+        sortedProblems[unsortedProblem.level].push({
           id: unsortedProblem.id,
           title: unsortedProblem.title,
           number: unsortedProblem.number,

--- a/src/components/widget/probleminfo/ProblemInfo.tsx
+++ b/src/components/widget/probleminfo/ProblemInfo.tsx
@@ -16,15 +16,14 @@ import { extractDescription, extractExample } from '@/util/problem';
 import { useGetProblemDetail } from '@/hooks/queries/problem';
 
 // types
-import { ProblemDetailType } from '@/type/problem';
+import { GetProblemDetailType } from '@/type/problem';
 
 const ProblemInfo = () => {
   const { problemId } = useParams();
 
   // 캐싱 데이터 사용 (없을 경우 queryFn 적용)
-  const { data: { data: problemDetailData = null } = {} } = useGetProblemDetail<ProblemDetailType>(
-    Number(problemId),
-  );
+  const { data: { data: problemDetailData = null } = {} } =
+    useGetProblemDetail<GetProblemDetailType>(Number(problemId));
 
   const [description, example, teaplate] = [
     problemDetailData !== null ? extractDescription(problemDetailData.description) : '',

--- a/src/components/widget/probleminfo/problemdetails/ProblemDetails.tsx
+++ b/src/components/widget/probleminfo/problemdetails/ProblemDetails.tsx
@@ -9,11 +9,11 @@ import {
 } from '../ProblemInfo.css';
 
 // types
-import { ProblemDetailType } from '@/type/problem';
+import { GetProblemDetailType } from '@/type/problem';
 
 interface ProblemDetailsProps {
   text: string;
-  codeBlock: ProblemDetailType['data']['description'] | ProblemDetailType['data']['template'];
+  codeBlock: GetProblemDetailType['data']['description'] | GetProblemDetailType['data']['template'];
 }
 
 const ProblemDetails = ({ text, codeBlock }: ProblemDetailsProps) => {

--- a/src/components/widget/probleminfo/testcases/TestCases.tsx
+++ b/src/components/widget/probleminfo/testcases/TestCases.tsx
@@ -12,11 +12,11 @@ import {
 } from './TestCases.css';
 
 // types
-import { ProblemDetailType } from '@/type/problem';
+import { GetProblemDetailType } from '@/type/problem';
 
 interface TestCasesProps {
   text: string;
-  testCases: ProblemDetailType['data']['testCase'];
+  testCases: GetProblemDetailType['data']['testCase'];
 }
 const TestCases = ({ text, testCases }: TestCasesProps) => {
   const [correctCases, validCases] = [

--- a/src/components/widget/probleminfo/title/Title.tsx
+++ b/src/components/widget/probleminfo/title/Title.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { ProblemDiffStyle, ProblemTitleStyle } from '../ProblemInfo.css';
 
 // types
-import { ProblemDetailType } from '@/type/problem';
+import { GetProblemDetailType } from '@/type/problem';
 
 interface TitleProps {
-  problemDetail: ProblemDetailType['data'];
+  problemDetail: GetProblemDetailType['data'];
 }
 
 const Title = ({ problemDetail }: TitleProps) => {

--- a/src/components/widget/problemmenus/ProblemMenus.tsx
+++ b/src/components/widget/problemmenus/ProblemMenus.tsx
@@ -27,7 +27,7 @@ const ProblemMenus = ({ problemDetail }: ProblemMenusProps) => {
 
   /**
    *
-   * 제출 현황 페이지 이동시 사용되는 URL 명세입니다.
+   * 아래 메뉴들 중, 제출 현황 페이지로 이동시 사용되는 URL 명세입니다.
    * https://localhost:3000/status?result_id=1&problem_id=172&[snsId=123]
    * @route GET /status
    * @param {string} query.result_id -  1:정답 , 2:오답 , 3:정확성 , -1:전부
@@ -42,7 +42,7 @@ const ProblemMenus = ({ problemDetail }: ProblemMenusProps) => {
         <li className={`${SingleButton} isFirst`}>
           <ProblemMenuButtons
             problemDiff={problemDetail.level}
-            problemId={problemDetail.id}
+            problemId={problemDetail.number}
             text={problemDetail.title}
             _onClick={() => {
               navigate(`/${PAGE_URL.Problem}/${problemDetail.id}`);

--- a/src/components/widget/problemmenus/ProblemMenus.tsx
+++ b/src/components/widget/problemmenus/ProblemMenus.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { ProblemMenuButtons } from '@/components/core';
 
 // types
-import { ProblemDetailType } from '@/type/problem';
+import { GetProblemDetailType } from '@/type/problem';
 
 // style
 import { SingleButton, ButtonList, ProblemMunusWrapperStyle } from './ProblemMenus.css';
@@ -16,7 +16,7 @@ import { useUserInfo } from '@/stores/useUserInfoStore';
 import { useIsAuth } from '@/stores/useAuthStore';
 
 interface ProblemMenusProps {
-  problemDetail: ProblemDetailType['data'];
+  problemDetail: GetProblemDetailType['data'];
 }
 
 const ProblemMenus = ({ problemDetail }: ProblemMenusProps) => {

--- a/src/components/widget/problemsubmit/ProblemSubmit.tsx
+++ b/src/components/widget/problemsubmit/ProblemSubmit.tsx
@@ -1,15 +1,26 @@
-import { useGetProblemDetail } from '@/hooks/queries/problem';
-import { useUserInfo } from '@/stores/useUserInfoStore';
-import { ProblemDetailType } from '@/type/problem';
-import { useMutation } from '@tanstack/react-query';
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { CodeInput, CodeInputWrapper } from './ProblemSubmit.css';
+
+// hooks
+import { useGetProblemDetail } from '@/hooks/queries/problem';
+import { useMutation } from '@tanstack/react-query';
+
+// store
+import { useUserInfo } from '@/stores/useUserInfoStore';
+
+// types
+import { GetProblemDetailType, PostSubmitResponseType } from '@/type/problem';
+
+// components
+import { BasicButton } from '@/components';
+
+// api
+import { problemApi } from '@/apis/problem';
+
 import AceEditor from 'react-ace';
 import 'ace-builds/src-noconflict/mode-typescript';
 import 'ace-builds/src-noconflict/theme-tomorrow';
-import { BasicButton } from '@/components';
-import { CodeInput, CodeInputWrapper } from './ProblemSubmit.css';
-import { problemApi } from '@/apis/problem';
 
 const ProblemSubmit = () => {
   const [code, setCode] = useState<string>('');
@@ -19,14 +30,13 @@ const ProblemSubmit = () => {
   const useInfo = useUserInfo();
 
   // 캐싱 데이터 사용 (없을 경우 queryFn 적용)
-  const { data: { data: problemDetailData = null } = {} } = useGetProblemDetail<ProblemDetailType>(
-    Number(problemId),
-  );
+  const { data: { data: problemDetailData = null } = {} } =
+    useGetProblemDetail<GetProblemDetailType>(Number(problemId));
 
   const { mutate: submitAnswerMutation } = useMutation(
     ['submit', problemId],
     async () => {
-      return await problemApi.postSumbitCode(problemId as string, code);
+      return await problemApi.postSumbitCode<PostSubmitResponseType>(problemId as string, code);
     },
     {
       onSuccess: (data) => {

--- a/src/hooks/queries/problem.ts
+++ b/src/hooks/queries/problem.ts
@@ -2,8 +2,8 @@ import { useQuery } from '@tanstack/react-query';
 
 import { problemApi } from '@/apis/problem';
 
-export const useGetProblems = <T>(options?: T) => {
-  return useQuery(['getProblems'], async () => await problemApi.getProblems(), {
+export const useGetProblems = <T, K = any>(options?: K) => {
+  return useQuery(['getProblems'], async () => await problemApi.getProblems<T>(), {
     retry: 0,
     onError: (err) => {
       console.log(err);
@@ -14,7 +14,7 @@ export const useGetProblems = <T>(options?: T) => {
   });
 };
 
-export const useGetProblemDetail = <T>(problemId: number | null, options?: T) => {
+export const useGetProblemDetail = <T, K = any>(problemId: number | null, options?: K) => {
   return useQuery<T>({
     queryKey: ['problemDetail', { problemId }],
     queryFn: async (): Promise<T> => {

--- a/src/type/login.ts
+++ b/src/type/login.ts
@@ -1,0 +1,6 @@
+export interface PostLoginResponseType {
+  message: string;
+  data: {
+    accessToken: string;
+  };
+}

--- a/src/type/problem.ts
+++ b/src/type/problem.ts
@@ -8,13 +8,17 @@ export interface ProblemType {
   number: number;
 }
 
-// API 전용
+export interface GetProblemListType {
+  message: string;
+  data: Array<ProblemType & { level: Level }>;
+}
+
 export interface TestCasesType {
   case: string;
   type: string;
 }
 
-export interface ProblemDetailType {
+export interface GetProblemDetailType {
   message: string;
   data: {
     createdAt: string;
@@ -30,30 +34,9 @@ export interface ProblemDetailType {
   };
 }
 
-// // 목데이터 전용으로 임시 생성.
-// export interface ProblemInfoType {
-//   problemId: number;
-//   problemTitle: string;
-//   problemDescription: string;
-//   example: string[];
-//   template: string[];
-//   testCases: string[];
-//   isSolved: boolean;
-// }
-
-// export type MainProblem = Pick<ProblemInfoType, 'problemId' | 'problemTitle'> & {
-//   isSolved?: boolean;
-// };
-
-// export interface MainProblem {
-//   'warm-up': ProblemInfoType[];
-//   easy: ProblemInfoType[];
-//   medium: ProblemInfoType[];
-//   hard: ProblemInfoType[];
-//   extreme: ProblemInfoType[];
-// }
-
-// export interface MainLevel {
-//   level: Level;
-//   count: number;
-// }
+export interface PostSubmitResponseType {
+  message: string;
+  data: {
+    submitCodeId: number;
+  };
+}

--- a/src/type/user.ts
+++ b/src/type/user.ts
@@ -1,0 +1,8 @@
+export interface GetUserInfoType {
+  message: string;
+  data: {
+    snsId: number;
+    name: string;
+    profileUrl: string;
+  };
+}

--- a/src/util/problem.ts
+++ b/src/util/problem.ts
@@ -1,4 +1,4 @@
-import { ProblemDetailType } from '@/type/problem';
+import { GetProblemDetailType } from '@/type/problem';
 
 // "problem/", "submit/"" URL 판별
 export const checkURL = (pathname: string) => {
@@ -41,6 +41,6 @@ export const extractExample = (readmeString: string) => {
 };
 
 // 테스트케이스 문자열 반환
-export const extractTestCases = (arr: ProblemDetailType['data']['testCase']) => {
+export const extractTestCases = (arr: GetProblemDetailType['data']['testCase']) => {
   return arr.map((i) => i.case).join('\n\n');
 };


### PR DESCRIPTION
### 💁‍♂️ PR 개요

- 문제 페이지에 접근하면 문제 메뉴 바에 문제의 번호가 아닌 ID를 보여줬었습니다. 그렇지만 ID대신 문제 번호를 보여주는것이 유저 입장에서 더 편리할 것 같다는 생각이 들어서 번호를 보여주는 것으로 수정했습니다
- API메소드에 타입을 사용하지 않았던 메소드들에 대해서 전부 타입을 적용했습니다

<br/>

### 📝 변경 사항

- 문제 메뉴 바에서 ID대신 문제 번호를 보여주는 것으로 수정
- API메소드에 타입 적용

<br/>

### 📷 스크린 샷 (선택)

- 문제 번호를 보여줍니다
   ![image](https://github.com/type-challenges-online-judge/toj-fe/assets/78631876/75dc5e4f-e062-4a09-9995-9e19d7571abd)

- 타입 추가
   ![image](https://github.com/type-challenges-online-judge/toj-fe/assets/78631876/4eb5ab23-48c1-4f06-be78-2e39fd97d113)
   ![image](https://github.com/type-challenges-online-judge/toj-fe/assets/78631876/a522925f-6e19-4f17-83ba-bfe28dae4172)
   ![image](https://github.com/type-challenges-online-judge/toj-fe/assets/78631876/f531e25f-19d2-4bfd-b127-11a087e45f89)

<br/>

### 🗣 리뷰어한테 할 말 (선택)

매인에서 머지하지 않고 바로 브랜치를 파서, 이전 브랜치 커밋 기록이 같이 딸려왔습니다ㅠ
`♻️ [refactor]: 문제 페이지 진입 시, 메뉴바에 문제 id대신 번호를 표시` 커밋부터 보시면 돼요

<br/>

### 🧪 테스트 범위 (선택)
