### PR TITLE
✨ [feat]: 로그인 페이지 생성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^18.2.0",
         "react-ace": "^10.1.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.11.0",
         "react-markdown": "^8.0.3",
         "react-query": "^4.0.0",
         "react-router-dom": "^6.15.0",
@@ -9881,6 +9882,14 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-icons": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
+      "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -18809,6 +18818,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-icons": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
+      "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "^18.2.0",
     "react-ace": "^10.1.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.11.0",
     "react-markdown": "^8.0.3",
     "react-query": "^4.0.0",
     "react-router-dom": "^6.15.0",

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -4,12 +4,15 @@ import axios, { AxiosError } from 'axios';
 
 export const API = axios.create({});
 
-export const tmpHandleLogout = () => {
+export const tmpHandleLogout = (url: string) => {
+  window.location.href = `${url}`;
+
   localStorage.removeItem('accessToken');
 
   delete API.defaults.headers.common.Authorization;
 
   useIsAuthStore.getState().setIsAuthState(false);
+
   useUserInfoStore.getState().setUserInfoState({
     userInfo: {
       snsId: 0,
@@ -26,7 +29,7 @@ API.interceptors.response.use(
     if (!(error instanceof AxiosError)) return;
     if (error.response !== undefined && error.response.status === 401) {
       alert('로그인 해 주세요');
-      tmpHandleLogout();
+      tmpHandleLogout('/login');
     }
 
     // return await Promise.reject(error);

--- a/src/apis/login.ts
+++ b/src/apis/login.ts
@@ -8,6 +8,7 @@ export const loginApi = {
       const apiResponse = await API.post('/api/auth/login', null, {
         params: { code: gitHubAuthCode },
       });
+
       const { accessToken } = apiResponse.data.data;
 
       localStorage.setItem('accessToken', JSON.stringify(accessToken));

--- a/src/components/core/button/ProblemMenuButtons.tsx
+++ b/src/components/core/button/ProblemMenuButtons.tsx
@@ -5,7 +5,6 @@ import { Level } from '@/type/problem';
 import { MenuButton, ProblemDiffAndId } from './ProblemButton.css';
 
 interface ProblemMenuButtonsProps {
-  isAuth?: boolean;
   problemDiff?: Level;
   problemId?: number;
   text: string;
@@ -13,14 +12,13 @@ interface ProblemMenuButtonsProps {
 }
 
 const ProblemMenuButtons = ({
-  isAuth,
   problemDiff,
   problemId,
   text,
   _onClick,
 }: ProblemMenuButtonsProps) => {
   return (
-    <button onClick={_onClick} className={MenuButton} disabled={isAuth === false}>
+    <button onClick={_onClick} className={MenuButton}>
       {problemDiff !== undefined && problemId !== undefined && (
         <div className={`${ProblemDiffAndId} ${problemDiff}`}>
           <span>{problemId}</span>

--- a/src/components/core/button/SignButton.css.ts
+++ b/src/components/core/button/SignButton.css.ts
@@ -1,6 +1,8 @@
 import { style } from '@vanilla-extract/css';
 
 export const SignButtonStyle = style({
+  display: 'flex',
+  alignItems: 'center',
   margin: '0 0 0 auto',
   padding: '5px 32px',
   border: '1px solid black',
@@ -9,6 +11,9 @@ export const SignButtonStyle = style({
   cursor: 'pointer',
 });
 
+export const ButtonTextStyle = style({
+  marginLeft: '10px',
+});
 export const SignButtonTextStyle = style({
   fontSize: '17px',
 });

--- a/src/components/core/button/SignButton.tsx
+++ b/src/components/core/button/SignButton.tsx
@@ -1,14 +1,16 @@
-import { SignButtonStyle } from './SignButton.css';
+import { BsGithub } from 'react-icons/bs';
+import { ButtonTextStyle, SignButtonStyle } from './SignButton.css';
 
 interface SignButtonProps {
   text: string;
   _onClick: () => void;
+  iconSize: number;
 }
 
-function SignButton({ text, _onClick }: SignButtonProps) {
+function SignButton({ text, _onClick, iconSize }: SignButtonProps) {
   return (
     <button className={SignButtonStyle} onClick={_onClick}>
-      {text}
+      <BsGithub size={iconSize} /> <span className={ButtonTextStyle}>{text}</span>
     </button>
   );
 }

--- a/src/components/widget/common/Navbar.tsx
+++ b/src/components/widget/common/Navbar.tsx
@@ -1,55 +1,20 @@
-import React, { useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { LogoStyle, NavbarStyle } from './Navbar.css';
 
 // components
 import { SignButton } from '@/components';
 
 // apis
-import { loginApi } from '@/apis/login';
 import { tmpHandleLogout } from '@/apis/instance';
-import { userApi } from '@/apis/user';
-
-// const
-import { GIT_HUB_LOGIN_URL } from '@/config/const';
 
 // store
-import { useIsAuth, useIsAuthActions } from '@/stores/useAuthStore';
-import { useUserInfoActions } from '@/stores/useUserInfoStore';
-
-// type
-import { GetUserInfoType } from '@/type/user';
-import { PostLoginResponseType } from '@/type/login';
+import { useIsAuth } from '@/stores/useAuthStore';
 
 const Navbar = () => {
-  const location = useLocation();
-  const urlParams = new URLSearchParams(location.search);
-  const codeQueryString = urlParams.get('code');
   const navigate = useNavigate();
 
   const isAuth = useIsAuth();
-  const setIsAuthState = useIsAuthActions();
-  const setUserInfoState = useUserInfoActions();
-
-  useEffect(() => {
-    const login = async () => {
-      const response = await loginApi.postLogin<PostLoginResponseType>(codeQueryString!);
-
-      if (response?.status === 201) {
-        setIsAuthState(true);
-
-        // URL에서 code 쿼리스트링 제거
-        urlParams.delete('code');
-        navigate(`${location.pathname}?${urlParams.toString()}`, { replace: true });
-
-        const response = await userApi.getUserInfo<GetUserInfoType>();
-        setUserInfoState({ userInfo: response!.data.data });
-      }
-    };
-    if (codeQueryString !== null) login();
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [codeQueryString]);
 
   const goMain = () => {
     navigate('/');
@@ -73,9 +38,10 @@ const Navbar = () => {
       <SignButton
         text={isAuth ? 'LOGOUT' : 'LOGIN'}
         _onClick={() => {
-          if (!isAuth) window.location.href = GIT_HUB_LOGIN_URL;
+          if (!isAuth) navigate(`/login`);
           if (isAuth) tmpHandleLogout();
         }}
+        iconSize={20}
       />
     </div>
   );

--- a/src/components/widget/common/Navbar.tsx
+++ b/src/components/widget/common/Navbar.tsx
@@ -39,7 +39,7 @@ const Navbar = () => {
         text={isAuth ? 'LOGOUT' : 'LOGIN'}
         _onClick={() => {
           if (!isAuth) navigate(`/login`);
-          if (isAuth) tmpHandleLogout();
+          if (isAuth) tmpHandleLogout('/');
         }}
         iconSize={20}
       />

--- a/src/components/widget/index.ts
+++ b/src/components/widget/index.ts
@@ -12,5 +12,10 @@ export { default as StatusBodyTr } from './status/StatusBodyTr';
 export { default as StatusHeader } from './status/StatusHeader';
 export { default as StatusBody } from './status/StatusBody';
 
+// problemmenus
+export { default as ProblemMenus } from './problemmenus/ProblemMenus';
+
+// login
+export { default as Login } from './login/Login';
+
 export * from './probleminfo';
-export * from './problemmenus';

--- a/src/components/widget/login/Login.css.ts
+++ b/src/components/widget/login/Login.css.ts
@@ -1,0 +1,1 @@
+// import { style } from '@vanilla-extract/css';

--- a/src/components/widget/login/Login.tsx
+++ b/src/components/widget/login/Login.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+// api
+import { loginApi } from '@/apis/login';
+import { userApi } from '@/apis/user';
+
+// components
+import { SignButton } from '@/components';
+
+// const
+import { GIT_HUB_LOGIN_URL } from '@/config/const';
+
+// store
+import { useIsAuthActions } from '@/stores/useAuthStore';
+import { useUserInfoActions } from '@/stores/useUserInfoStore';
+
+// types
+import { PostLoginResponseType } from '@/type/login';
+import { GetUserInfoType } from '@/type/user';
+
+const Login = () => {
+  const location = useLocation();
+  const urlParams = new URLSearchParams(location.search);
+  const codeQueryString = urlParams.get('code');
+  const navigate = useNavigate();
+  const setIsAuthState = useIsAuthActions();
+  const setUserInfoState = useUserInfoActions();
+
+  useEffect(() => {
+    const login = async () => {
+      const response = await loginApi.postLogin<PostLoginResponseType>(codeQueryString!);
+
+      if (response?.status === 201) {
+        setIsAuthState(true);
+
+        // code 쿼리스트링 제거
+        // urlParams.delete('code');
+        // navigate(`${location.pathname}?${urlParams.toString()}`, { replace: true });
+
+        const response = await userApi.getUserInfo<GetUserInfoType>();
+        setUserInfoState({ userInfo: response!.data.data });
+        navigate(`/`);
+      }
+    };
+    if (codeQueryString !== null) login();
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [codeQueryString]);
+
+  return (
+    <div>
+      {codeQueryString === null ? (
+        <SignButton
+          text="GitHub Login"
+          _onClick={() => (window.location.href = GIT_HUB_LOGIN_URL)}
+          iconSize={50}
+        />
+      ) : (
+        'Loading...'
+      )}
+    </div>
+  );
+};
+
+export default Login;

--- a/src/components/widget/problemmenus/ProblemMenus.tsx
+++ b/src/components/widget/problemmenus/ProblemMenus.tsx
@@ -15,26 +15,30 @@ import { PAGE_URL } from '@/config/path';
 import { useUserInfo } from '@/stores/useUserInfoStore';
 import { useIsAuth } from '@/stores/useAuthStore';
 
+/**
+ *
+ * 제출 현황 페이지 이동시 사용되는 URL 명세입니다.
+ * https://localhost:3000/status?result_id=1&problem_id=172&[sns_id=123]
+ * @route GET /status
+ * @param {string} query.result_id -  1:정답 , 2:오답 , 3:정확성 , -1:전부
+ * @param {number} query.problem_id - 문제의 ID를 나타냅니다.
+ * @param {string} query.snsId - GITHUB의 유저ID값을 의미합니다 (존재할 경우 내 제출, 없을 경우 모든 유저 제출)
+ * @returns {Object} Response object
+ */
+
 interface ProblemMenusProps {
   problemDetail: GetProblemDetailType['data'];
 }
 
 const ProblemMenus = ({ problemDetail }: ProblemMenusProps) => {
   const navigate = useNavigate();
-
   const isAuth = useIsAuth();
   const userInfo = useUserInfo();
 
-  /**
-   *
-   * 제출 현황 페이지 이동시 사용되는 URL 명세입니다.
-   * https://localhost:3000/status?result_id=1&problem_id=172&[sns_id=123]
-   * @route GET /status
-   * @param {string} query.result_id -  1:정답 , 2:오답 , 3:정확성 , -1:전부
-   * @param {number} query.problem_id - 문제의 ID를 나타냅니다.
-   * @param {string} query.snsId - GITHUB의 유저ID값을 의미합니다 (존재할 경우 내 제출, 없을 경우 모든 유저 제출)
-   * @returns {Object} Response object
-   */
+  const redirectLogin = () => {
+    alert('로그인이 필요한 서비스 입니다');
+    navigate(`/login`);
+  };
 
   return (
     <div className={ProblemMunusWrapperStyle}>
@@ -52,10 +56,12 @@ const ProblemMenus = ({ problemDetail }: ProblemMenusProps) => {
 
         <li className={SingleButton}>
           <ProblemMenuButtons
-            isAuth={isAuth}
             text="제출하기"
             _onClick={() => {
-              navigate(`/${PAGE_URL.Submit}/${problemDetail.id}`);
+              if (!isAuth) {
+                redirectLogin();
+              }
+              if (isAuth) navigate(`/${PAGE_URL.Submit}/${problemDetail.id}`);
             }}
           />
         </li>
@@ -69,12 +75,16 @@ const ProblemMenus = ({ problemDetail }: ProblemMenusProps) => {
         </li>
         <li className={`${SingleButton} isLast`}>
           <ProblemMenuButtons
-            isAuth={isAuth}
             text="내 제출"
             _onClick={() => {
-              navigate(
-                `/${PAGE_URL.Status}?result_id=-1&problem_id=${problemDetail.id}&sns_id=${userInfo.snsId}`,
-              );
+              if (!isAuth) {
+                redirectLogin();
+              }
+              if (isAuth) {
+                navigate(
+                  `/${PAGE_URL.Status}?result_id=-1&problem_id=${problemDetail.id}&sns_id=${userInfo.snsId}`,
+                );
+              }
             }}
           />
         </li>

--- a/src/components/widget/problemmenus/index.ts
+++ b/src/components/widget/problemmenus/index.ts
@@ -1,1 +1,0 @@
-export { default as ProblemMenus } from './ProblemMenus';

--- a/src/config/path.ts
+++ b/src/config/path.ts
@@ -3,4 +3,5 @@ export enum PAGE_URL {
   Problem = 'problem',
   Submit = 'submit',
   Status = 'status',
+  Login = 'login',
 }

--- a/src/pages/PageRouter.tsx
+++ b/src/pages/PageRouter.tsx
@@ -12,6 +12,7 @@ const PageRouter = () => {
       <Routes>
         <Route path={PAGE_URL.Main} element={<CommonLayout />}>
           <Route index element={<Switch.MainPage />} />
+          <Route path={`${PAGE_URL.Login}`} element={<Switch.LoginPage />} />
         </Route>
         <Route path="/*" element={<CommonLayoutWithMenus />}>
           <Route path={`${PAGE_URL.Problem}/:problemId`} element={<Switch.ProblemPage />} />

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -4,3 +4,4 @@ export * from './problem';
 export * from './main';
 export * from './submit';
 export * from './status';
+export * from './login';

--- a/src/pages/login/LoginPage.css.ts
+++ b/src/pages/login/LoginPage.css.ts
@@ -1,0 +1,8 @@
+import { style } from '@vanilla-extract/css';
+
+export const LoginpageWrapperStyle = style({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  height: 'calc(100vh - 61.77px)',
+});

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Login } from '@/components';
+import { LoginpageWrapperStyle } from './LoginPage.css';
+
+const LoginPage = () => {
+  return (
+    <div className={LoginpageWrapperStyle}>
+      <Login />
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/src/pages/login/index.ts
+++ b/src/pages/login/index.ts
@@ -1,0 +1,1 @@
+export { default as LoginPage } from './LoginPage';

--- a/src/pages/problem/ProblemPage.tsx
+++ b/src/pages/problem/ProblemPage.tsx
@@ -3,7 +3,6 @@ import { ProblemPageStyle } from './ProblemPage.css';
 
 // components
 import { ProblemInfo } from '@/components/widget';
-import { SubmitType } from '@/type/status';
 
 const ProblemPage = () => {
   return (


### PR DESCRIPTION
### 💁‍♂️ PR 개요

- 로그인 페이지를 생성합니다
- 이에 따른 로직들을 수정합니다
- #{issue number}

<br/>

### 📝 변경 사항

- 로그인을 진행할 수 있는 페이지를 새로 생성합합니다
- 로그인 상태를 기반으로 제출하기 , 내 제출 버튼을 `disabled` 하는 것보다 , 클릭 시 로그인 페이지로 이동하게 합니다
- 로그아웃 시 , 인자로 받은 페이지 URL로 전환 합니다


<br/>

### 📷 스크린 샷 (선택)

![image](https://github.com/type-challenges-online-judge/toj-fe/assets/78631876/17b6553d-9b7b-446e-95f1-9a642ad01f3f)

<br/>

### 🗣 리뷰어한테 할 말 (선택)

- 디자인은 우선순위로 생각하지 않았기에 추후 수정하겠습니다
- 나중에 `Zustand`를 이용해서 로그인/로그아웃시 사용자가 직전에 방문했던 페이지로 돌아가게끔 수정하겠습니다

<br/>

### 🧪 테스트 범위 (선택)

close #82 