### PR TITLE
:sparkles: [feat]: 로그인 기반 메인페이지 푼 문제들 색상 변경 구현

### DIFF
--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -6,6 +6,7 @@ export const API = axios.create({});
 
 export const tmpHandleLogout = (url?: string) => {
   if (url !== undefined) window.location.href = `${url}`;
+  if (url === undefined) window.location.reload();
 
   localStorage.removeItem('accessToken');
 

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -11,4 +11,18 @@ export const userApi = {
       if (e instanceof AxiosError) console.error(e.message);
     }
   },
+  getSolvedProblemList: async (
+    snsId: number,
+    minify: boolean,
+  ): Promise<AxiosResponse<any> | undefined> => {
+    try {
+      const apiResponse = await API.get(`/api/user/solved`, {
+        params: { snsId, minify },
+      });
+
+      return apiResponse;
+    } catch (e) {
+      if (e instanceof AxiosError) console.error(e.message);
+    }
+  },
 };

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -11,12 +11,12 @@ export const userApi = {
       if (e instanceof AxiosError) console.error(e.message);
     }
   },
-  getSolvedProblemList: async (
+  getSolvedProblemList: async <T>(
     snsId: number,
     minify: boolean,
-  ): Promise<AxiosResponse<any> | undefined> => {
+  ): Promise<AxiosResponse<T> | undefined> => {
     try {
-      const apiResponse = await API.get(`/api/user/solved`, {
+      const apiResponse = await API.get<T>(`/api/user/solved`, {
         params: { snsId, minify },
       });
 

--- a/src/components/widget/main/MainProblems.tsx
+++ b/src/components/widget/main/MainProblems.tsx
@@ -10,10 +10,25 @@ import {
   MainLevelProblemsWrapperStyle,
   MainProblemsWrapperStyle,
 } from './MainProblems.css';
+import { useUserInfo } from '@/stores/useUserInfoStore';
+import { useGetSolvedProblemsList } from '@/hooks/queries/user';
 
 const MainProblems = () => {
   const [problems, setProblems] = useState<ProblemsType>();
+  const [solvedId, setSolvedId] = useState<Set<number>>(new Set());
+  const userInfo = useUserInfo();
+
   const { data: { data: unsortedProblems = null } = {} } = useGetProblems<GetProblemListType>();
+  const { data: { data: solvedIdList = [] } = {} } = useGetSolvedProblemsList(
+    userInfo.snsId,
+    false,
+  );
+
+  useEffect(() => {
+    if (solvedIdList.length > 0) {
+      setSolvedId(new Set(new Set(solvedIdList.map((solvedData: any) => solvedData.id))));
+    }
+  }, [solvedIdList]);
 
   const navigate = useNavigate();
 
@@ -58,7 +73,7 @@ const MainProblems = () => {
                         id={problem.number}
                         text={problem.title}
                         level={level as Level}
-                        isSolved={false}
+                        isSolved={solvedId.has(problem.id)}
                         _onClick={() => {
                           moveProblemDetail(problem.id);
                         }}

--- a/src/components/widget/main/MainProblems.tsx
+++ b/src/components/widget/main/MainProblems.tsx
@@ -11,7 +11,8 @@ import {
   MainProblemsWrapperStyle,
 } from './MainProblems.css';
 import { useUserInfo } from '@/stores/useUserInfoStore';
-import { useGetSolvedProblemsList } from '@/hooks/queries/user';
+import { useGetSolvedProblemList } from '@/hooks/queries/user';
+import { GetSolvedListType } from '@/type/user';
 
 const MainProblems = () => {
   const [problems, setProblems] = useState<ProblemsType>();
@@ -19,14 +20,14 @@ const MainProblems = () => {
   const userInfo = useUserInfo();
 
   const { data: { data: unsortedProblems = null } = {} } = useGetProblems<GetProblemListType>();
-  const { data: { data: solvedIdList = [] } = {} } = useGetSolvedProblemsList(
+  const { data: { data: solvedIdList = [] } = {} } = useGetSolvedProblemList<GetSolvedListType>(
     userInfo.snsId,
     false,
   );
 
   useEffect(() => {
     if (solvedIdList.length > 0) {
-      setSolvedId(solvedIdList.map((solvedData: any) => solvedData.id));
+      setSolvedId(solvedIdList.map((solvedData) => solvedData.id));
     }
   }, [solvedIdList]);
 

--- a/src/components/widget/main/MainProblems.tsx
+++ b/src/components/widget/main/MainProblems.tsx
@@ -15,7 +15,7 @@ import { useGetSolvedProblemsList } from '@/hooks/queries/user';
 
 const MainProblems = () => {
   const [problems, setProblems] = useState<ProblemsType>();
-  const [solvedId, setSolvedId] = useState<Set<number>>(new Set());
+  const [solvedId, setSolvedId] = useState<number[]>([]);
   const userInfo = useUserInfo();
 
   const { data: { data: unsortedProblems = null } = {} } = useGetProblems<GetProblemListType>();
@@ -26,7 +26,7 @@ const MainProblems = () => {
 
   useEffect(() => {
     if (solvedIdList.length > 0) {
-      setSolvedId(new Set(new Set(solvedIdList.map((solvedData: any) => solvedData.id))));
+      setSolvedId(solvedIdList.map((solvedData: any) => solvedData.id));
     }
   }, [solvedIdList]);
 
@@ -73,7 +73,7 @@ const MainProblems = () => {
                         id={problem.number}
                         text={problem.title}
                         level={level as Level}
-                        isSolved={solvedId.has(problem.id)}
+                        isSolved={solvedId.includes(problem.id)}
                         _onClick={() => {
                           moveProblemDetail(problem.id);
                         }}

--- a/src/hooks/queries/user.ts
+++ b/src/hooks/queries/user.ts
@@ -1,7 +1,7 @@
 import { userApi } from '@/apis/user';
 import { useQuery } from '@tanstack/react-query';
 
-export const useGetSolvedProblemsList = <T, K = any>(
+export const useGetSolvedProblemList = <T, K = any>(
   snsId: number,
   minify: boolean,
   options?: K,
@@ -9,7 +9,7 @@ export const useGetSolvedProblemsList = <T, K = any>(
   return useQuery({
     queryKey: ['solvedList', snsId],
     queryFn: async () => {
-      const res = await userApi.getSolvedProblemList(snsId, minify);
+      const res = await userApi.getSolvedProblemList<T>(snsId, minify);
       return res?.data;
     },
     retry: 0,

--- a/src/hooks/queries/user.ts
+++ b/src/hooks/queries/user.ts
@@ -7,7 +7,7 @@ export const useGetSolvedProblemsList = <T, K = any>(
   options?: K,
 ) => {
   return useQuery({
-    queryKey: ['solvedList'],
+    queryKey: ['solvedList', snsId],
     queryFn: async () => {
       const res = await userApi.getSolvedProblemList(snsId, minify);
       return res?.data;

--- a/src/hooks/queries/user.ts
+++ b/src/hooks/queries/user.ts
@@ -1,0 +1,19 @@
+import { userApi } from '@/apis/user';
+import { useQuery } from '@tanstack/react-query';
+
+export const useGetSolvedProblemsList = <T, K = any>(
+  snsId: number,
+  minify: boolean,
+  options?: K,
+) => {
+  return useQuery({
+    queryKey: ['solvedList'],
+    queryFn: async () => {
+      const res = await userApi.getSolvedProblemList(snsId, minify);
+      return res?.data;
+    },
+    retry: 0,
+    enabled: snsId !== 0,
+    ...options,
+  });
+};

--- a/src/type/status.ts
+++ b/src/type/status.ts
@@ -1,7 +1,6 @@
 import { ProblemType } from './problem';
 import { UserType } from './user';
 
-// 목데이터 전용으로 임시 생성.
 export interface StatusType {
   code: string;
   correct_score: number;

--- a/src/type/user.ts
+++ b/src/type/user.ts
@@ -11,3 +11,16 @@ export interface UserType {
   snsId: number;
   name: string;
 }
+
+export interface GetSolvedListType {
+  message: string;
+  data: [
+    {
+      id: number;
+      title: string;
+      level: string;
+      number: number;
+      oldestSolvedDate: string;
+    },
+  ];
+}


### PR DESCRIPTION
### 💁‍♂️ PR 개요

메인 페이지 로그인한 계정으로 풀었던 문제들을 회색으로 표시 합니다
- #91 

<br/>

### 📝 변경 사항

- 풀었던 문제들을 불러오는 새 API 생성
- 해당 API 기반으로 조건부 스타일 적용


<br/>

### 📷 스크린 샷 (선택)

![image](https://github.com/type-challenges-online-judge/toj-fe/assets/78631876/cd349c40-a1c6-487f-80f2-2fa39d1c0c9f)


<br/>

### 🗣 리뷰어한테 할 말 (선택)


<br/>

### 🧪 테스트 범위 (선택)

close #91 