### PR TITLE
:bug: [fix]: 새로고침시 동작하는 인증 로직에 useEffect 제거

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,11 +10,9 @@ import { API } from './apis/instance';
 
 function App() {
   const localStorageToken = localStorage.getItem('accessToken');
-  useEffect(() => {
-    if (localStorageToken !== null) {
-      API.defaults.headers.common.Authorization = `Bearer ${JSON.parse(localStorageToken)}`;
-    }
-  }, [localStorageToken]);
+  if (localStorageToken !== null) {
+    API.defaults.headers.common.Authorization = `Bearer ${JSON.parse(localStorageToken)}`;
+  }
 
   return (
     <>


### PR DESCRIPTION
### 💁‍♂️ PR 개요

인증 필요 페이지에서 새로고침시, 로그아웃이 돼버리는 버그를 수정 합니다
- #98 

<br/>

### 📝 변경 사항

- 새로고침을 할 때 최상단 컴포넌트인 `App.tsx`에서 `accessToken` 을 가져온 뒤 api요청의 header로 넣어주는 과정을
`useEffect` 없이 진행합니다. 

<br>

`useEffect`는 `App.tsx` 가 먼저 렌더링 된 후 진행하게 되는데 렌더링이 되는 과정에서
인증 로직 `Authorization.tsx` 가 먼저 동작해버려서 401발생 -> `interceptors` 동작으로 로그아웃이 진행 됐었습니다

<br/>

### 📷 스크린 샷 (선택)

<br/>

### 🗣 리뷰어한테 할 말 (선택)

- 집중적으로 리뷰해주었으면 하는 부분 설명

<br/>

### 🧪 테스트 범위 (선택)


close #98 