### PR TITLE
🐛 [fix]: 정답 보기와 내 제출 페이지를 드나들 때마다 버튼 슬라이싱 상태 초기화

### DIFF
--- a/src/components/core/button/PaginationButtons.tsx
+++ b/src/components/core/button/PaginationButtons.tsx
@@ -1,11 +1,23 @@
-import { COUNT_PER_PAGE, MAXIMUM_PAGE_BUTTON_COUNT } from '@/config/const';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+// styles
 import { ButtonsStyle, PaginationButtonsWrapperStyle } from './PaginationButtons.css';
+
+// const
+import { COUNT_PER_PAGE } from '@/config/const';
+
+// components
 import GoLeft from './GoLeft';
 import GoRight from './GoRight';
-import { LuMoreHorizontal } from 'react-icons/lu';
 import GoStart from './GoStart';
 import GoEnd from './GoEnd';
+
+// icon
+import { LuMoreHorizontal } from 'react-icons/lu';
+
+// util
+import { getLastPageSlicedIndexAtFirst } from '@/util/status';
 
 interface PaginationButtonsProps {
   totalSize: number;
@@ -13,13 +25,20 @@ interface PaginationButtonsProps {
   setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
 }
 const PaginationButtons = ({ totalSize, currentPage, setCurrentPage }: PaginationButtonsProps) => {
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+
+  const snsId = Number(queryParams.get('sns_id'));
   const LAST_PAGE_NUMBER = Math.ceil(totalSize / COUNT_PER_PAGE);
   const [slicedPageInex, setSlicedPageInex] = useState([
     1,
-    LAST_PAGE_NUMBER < MAXIMUM_PAGE_BUTTON_COUNT
-      ? LAST_PAGE_NUMBER + 1
-      : MAXIMUM_PAGE_BUTTON_COUNT + 1,
+    getLastPageSlicedIndexAtFirst(LAST_PAGE_NUMBER),
   ]);
+
+  useEffect(() => {
+    setSlicedPageInex([1, getLastPageSlicedIndexAtFirst(LAST_PAGE_NUMBER)]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [snsId]);
 
   return (
     <div className={PaginationButtonsWrapperStyle}>

--- a/src/pages/status/Status.tsx
+++ b/src/pages/status/Status.tsx
@@ -49,6 +49,7 @@ const Status = () => {
   useEffect(() => {
     submitSizeRefetch();
     submitListRefetch();
+    setCurrentPage(1);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [snsId]);
 

--- a/src/util/status.ts
+++ b/src/util/status.ts
@@ -1,0 +1,9 @@
+import { MAXIMUM_PAGE_BUTTON_COUNT } from '@/config/const';
+
+export const getLastPageSlicedIndexAtFirst = (lastPageNumber: number): number => {
+  if (lastPageNumber < MAXIMUM_PAGE_BUTTON_COUNT) {
+    return lastPageNumber + 1;
+  } else {
+    return MAXIMUM_PAGE_BUTTON_COUNT + 1;
+  }
+};


### PR DESCRIPTION
### 💁‍♂️ PR 개요

제출 현황 페이지에서 내 제출과 정답 보기 페이지를 서로 이동할 때, 페이지네이션의 버튼 리스트들이 잘못 나오는 오류를 해결합니다.
- #102 

<br/>

### 📝 변경 사항

현재 제출 현황의 내 제출 페이지와 정답 보기 페이지는 같은 페이지를 쿼리스트링 기반으로 재사용 하고 있습니다.
**그렇기 때문에 내 제출 페이지와 정답 보기를 각각 진입할 때마다 제출 내역의 정보가 아예 달라지게 됩니다**
-  그러므로 내 제출 페이지와 정답 보기 페이지를 각각 진입할 때마다 현재 페이지를 1 페이지로 초기화 하고
-  전체 버튼을 슬라이싱하는 인덱스들을 **다시 초기 상황을 기준으로 계산해서 업데이트** 합니다

<br/>

### 📷 스크린 샷 (선택)

<br/>

### 🗣 리뷰어한테 할 말 (선택)


<br/>

### 🧪 테스트 범위 (선택)

close #102 
